### PR TITLE
feat: jwt 재발급 api 구현

### DIFF
--- a/src/main/java/com/permitseoul/permitserver/auth/controller/AuthController.java
+++ b/src/main/java/com/permitseoul/permitserver/auth/controller/AuthController.java
@@ -1,6 +1,7 @@
 package com.permitseoul.permitserver.auth.controller;
 
 import com.permitseoul.permitserver.auth.domain.Token;
+import com.permitseoul.permitserver.auth.domain.TokenType;
 import com.permitseoul.permitserver.auth.dto.LoginRequest;
 import com.permitseoul.permitserver.auth.dto.TokenDto;
 import com.permitseoul.permitserver.auth.dto.SignUpRequest;
@@ -38,12 +39,7 @@ public class AuthController {
                 signUpRequest.socialType(),
                 signUpRequest.socialAccessToken()
         );
-        final ResponseCookie accessTokenCookie = CookieCreatorUtil.createAccessTokenCookie(tokenDto.accessToken());
-        final ResponseCookie refreshTokenCookie = CookieCreatorUtil.createRefreshTokenCookie(tokenDto.refreshToken());
-        response.setHeader("Set-Cookie", accessTokenCookie.toString());
-        response.addHeader("Set-Cookie", refreshTokenCookie.toString());
-
-        return ApiResponseUtil.success(SuccessCode.CREATED);
+        return getBaseResponseResponseEntity(response, tokenDto);
     }
 
     //로그인
@@ -53,12 +49,7 @@ public class AuthController {
             final HttpServletResponse response
     ) {
         final TokenDto tokenDto = authService.login(loginRequest.socialType(), loginRequest.authorizationCode(), loginRequest.redirectUrl());
-        final ResponseCookie accessTokenCookie = CookieCreatorUtil.createAccessTokenCookie(tokenDto.accessToken());
-        final ResponseCookie refreshTokenCookie = CookieCreatorUtil.createRefreshTokenCookie(tokenDto.refreshToken());
-        response.setHeader("Set-Cookie", accessTokenCookie.toString());
-        response.addHeader("Set-Cookie", refreshTokenCookie.toString());
-
-        return ApiResponseUtil.success(SuccessCode.CREATED);
+        return getBaseResponseResponseEntity(response, tokenDto);
     }
 
     //jwt 재발급
@@ -68,6 +59,10 @@ public class AuthController {
             final HttpServletResponse response
     ) {
         final TokenDto tokenDto = authService.reissue(refreshCookie.getValue());
+        return getBaseResponseResponseEntity(response, tokenDto);
+    }
+
+    private ResponseEntity<BaseResponse<?>> getBaseResponseResponseEntity(HttpServletResponse response, TokenDto tokenDto) {
         final ResponseCookie accessTokenCookie = CookieCreatorUtil.createAccessTokenCookie(tokenDto.accessToken());
         final ResponseCookie refreshTokenCookie = CookieCreatorUtil.createRefreshTokenCookie(tokenDto.refreshToken());
         response.setHeader("Set-Cookie", accessTokenCookie.toString());

--- a/src/main/java/com/permitseoul/permitserver/auth/controller/AuthController.java
+++ b/src/main/java/com/permitseoul/permitserver/auth/controller/AuthController.java
@@ -1,13 +1,16 @@
 package com.permitseoul.permitserver.auth.controller;
 
+import com.permitseoul.permitserver.auth.domain.Token;
 import com.permitseoul.permitserver.auth.dto.LoginRequest;
 import com.permitseoul.permitserver.auth.dto.TokenDto;
 import com.permitseoul.permitserver.auth.dto.SignUpRequest;
+import com.permitseoul.permitserver.auth.jwt.CookieCreatorUtil;
 import com.permitseoul.permitserver.auth.service.AuthService;
 import com.permitseoul.permitserver.global.Constants;
 import com.permitseoul.permitserver.global.response.ApiResponseUtil;
 import com.permitseoul.permitserver.global.response.BaseResponse;
 import com.permitseoul.permitserver.global.response.code.SuccessCode;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -35,22 +38,8 @@ public class AuthController {
                 signUpRequest.socialType(),
                 signUpRequest.socialAccessToken()
         );
-
-        final ResponseCookie accessTokenCookie = ResponseCookie.from(Constants.ACCESS_TOKEN, tokenDto.accessToken())
-                .maxAge(365L * 24 * 60 * 60) ///todo: 추후에 변경
-                .path("/")
-                .httpOnly(true)
-                .secure(true)
-                .sameSite("Strict")
-                .build();
-        final ResponseCookie refreshTokenCookie = ResponseCookie.from(Constants.REFRESH_TOKEN, tokenDto.refreshToken())
-                .maxAge(365L * 24 * 60 * 60) ///todo: 추후에 변경
-                .path("/")
-                .httpOnly(true)
-                .secure(true)
-                .sameSite("Strict")
-                .build();
-
+        final ResponseCookie accessTokenCookie = CookieCreatorUtil.createAccessTokenCookie(tokenDto.accessToken());
+        final ResponseCookie refreshTokenCookie = CookieCreatorUtil.createRefreshTokenCookie(tokenDto.refreshToken());
         response.setHeader("Set-Cookie", accessTokenCookie.toString());
         response.addHeader("Set-Cookie", refreshTokenCookie.toString());
 
@@ -64,22 +53,23 @@ public class AuthController {
             final HttpServletResponse response
     ) {
         final TokenDto tokenDto = authService.login(loginRequest.socialType(), loginRequest.authorizationCode(), loginRequest.redirectUrl());
+        final ResponseCookie accessTokenCookie = CookieCreatorUtil.createAccessTokenCookie(tokenDto.accessToken());
+        final ResponseCookie refreshTokenCookie = CookieCreatorUtil.createRefreshTokenCookie(tokenDto.refreshToken());
+        response.setHeader("Set-Cookie", accessTokenCookie.toString());
+        response.addHeader("Set-Cookie", refreshTokenCookie.toString());
 
-        final ResponseCookie accessTokenCookie = ResponseCookie.from(Constants.ACCESS_TOKEN, tokenDto.accessToken())
-                .maxAge(365L * 24 * 60 * 60) ///todo: 추후에 변경
-                .path("/")
-                .httpOnly(true)
-                .secure(true)
-                .sameSite("Strict")
-                .build();
-        final ResponseCookie refreshTokenCookie = ResponseCookie.from(Constants.REFRESH_TOKEN, tokenDto.refreshToken())
-                .maxAge(365L * 24 * 60 * 60) ///todo: 추후에 변경
-                .path("/")
-                .httpOnly(true)
-                .secure(true)
-                .sameSite("Strict")
-                .build();
+        return ApiResponseUtil.success(SuccessCode.CREATED);
+    }
 
+    //jwt 재발급
+    @PostMapping("/reissue")
+    public ResponseEntity<BaseResponse<?>> reissue(
+            @CookieValue(name = Constants.REFRESH_TOKEN) Cookie refreshCookie,
+            final HttpServletResponse response
+    ) {
+        final TokenDto tokenDto = authService.reissue(refreshCookie.getValue());
+        final ResponseCookie accessTokenCookie = CookieCreatorUtil.createAccessTokenCookie(tokenDto.accessToken());
+        final ResponseCookie refreshTokenCookie = CookieCreatorUtil.createRefreshTokenCookie(tokenDto.refreshToken());
         response.setHeader("Set-Cookie", accessTokenCookie.toString());
         response.addHeader("Set-Cookie", refreshTokenCookie.toString());
 

--- a/src/main/java/com/permitseoul/permitserver/auth/domain/TokenType.java
+++ b/src/main/java/com/permitseoul/permitserver/auth/domain/TokenType.java
@@ -1,8 +1,15 @@
 package com.permitseoul.permitserver.auth.domain;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import lombok.ToString;
 
+@RequiredArgsConstructor
+@Getter
 public enum TokenType {
-    ACCESS_TOKEN,
-    REFRESH_TOKEN,
+    ACCESS_TOKEN("accessToken"),
+    REFRESH_TOKEN("refreshToken"),
+
+    ;
+    private final String value;
 }

--- a/src/main/java/com/permitseoul/permitserver/auth/jwt/CookieCreatorUtil.java
+++ b/src/main/java/com/permitseoul/permitserver/auth/jwt/CookieCreatorUtil.java
@@ -7,7 +7,7 @@ import org.springframework.http.ResponseCookie;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class CookieCreatorUtil {
-    private static final long AT_MAX_AGE = 4L; // todo: 추후 변경
+    private static final long AT_MAX_AGE = 365L * 24 * 60 * 60; // todo: 추후 변경
     private static final long RT_MAX_AGE = 365L * 24 * 60 * 60; // todo: 추후 변경
 
     public static ResponseCookie createAccessTokenCookie(final String accessToken) {
@@ -15,7 +15,7 @@ public class CookieCreatorUtil {
                 .maxAge(AT_MAX_AGE)
                 .path("/")
                 .httpOnly(true)
-                .secure(false)
+                .secure(true)
                 .sameSite("Strict")
                 .build();
     }
@@ -25,7 +25,7 @@ public class CookieCreatorUtil {
                 .maxAge(RT_MAX_AGE)
                 .path("/")
                 .httpOnly(true)
-                .secure(false)
+                .secure(true)
                 .sameSite("Strict")
                 .build();
     }

--- a/src/main/java/com/permitseoul/permitserver/auth/jwt/CookieCreatorUtil.java
+++ b/src/main/java/com/permitseoul/permitserver/auth/jwt/CookieCreatorUtil.java
@@ -7,24 +7,25 @@ import org.springframework.http.ResponseCookie;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class CookieCreatorUtil {
-    private static final long DEFAULT_MAX_AGE = 365L * 24 * 60 * 60; // todo: 추후 변경
+    private static final long AT_MAX_AGE = 4L; // todo: 추후 변경
+    private static final long RT_MAX_AGE = 365L * 24 * 60 * 60; // todo: 추후 변경
 
     public static ResponseCookie createAccessTokenCookie(final String accessToken) {
         return ResponseCookie.from(Constants.ACCESS_TOKEN, accessToken)
-                .maxAge(DEFAULT_MAX_AGE)
+                .maxAge(AT_MAX_AGE)
                 .path("/")
                 .httpOnly(true)
-                .secure(true)
+                .secure(false)
                 .sameSite("Strict")
                 .build();
     }
 
     public static ResponseCookie createRefreshTokenCookie(final String refreshToken) {
         return ResponseCookie.from(Constants.REFRESH_TOKEN, refreshToken)
-                .maxAge(DEFAULT_MAX_AGE)
+                .maxAge(RT_MAX_AGE)
                 .path("/")
                 .httpOnly(true)
-                .secure(true)
+                .secure(false)
                 .sameSite("Strict")
                 .build();
     }

--- a/src/main/java/com/permitseoul/permitserver/auth/jwt/CookieCreatorUtil.java
+++ b/src/main/java/com/permitseoul/permitserver/auth/jwt/CookieCreatorUtil.java
@@ -1,0 +1,31 @@
+package com.permitseoul.permitserver.auth.jwt;
+
+import com.permitseoul.permitserver.global.Constants;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.springframework.http.ResponseCookie;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class CookieCreatorUtil {
+    private static final long DEFAULT_MAX_AGE = 365L * 24 * 60 * 60; // todo: 추후 변경
+
+    public static ResponseCookie createAccessTokenCookie(final String accessToken) {
+        return ResponseCookie.from(Constants.ACCESS_TOKEN, accessToken)
+                .maxAge(DEFAULT_MAX_AGE)
+                .path("/")
+                .httpOnly(true)
+                .secure(true)
+                .sameSite("Strict")
+                .build();
+    }
+
+    public static ResponseCookie createRefreshTokenCookie(final String refreshToken) {
+        return ResponseCookie.from(Constants.REFRESH_TOKEN, refreshToken)
+                .maxAge(DEFAULT_MAX_AGE)
+                .path("/")
+                .httpOnly(true)
+                .secure(true)
+                .sameSite("Strict")
+                .build();
+    }
+}

--- a/src/main/java/com/permitseoul/permitserver/auth/jwt/JwtGenerator.java
+++ b/src/main/java/com/permitseoul/permitserver/auth/jwt/JwtGenerator.java
@@ -33,11 +33,11 @@ public class JwtGenerator {
         final Date expireDate = generateExpirationDate(now, TokenType.ACCESS_TOKEN);
 
         final Claims claims = Jwts.claims();
+        claims.setSubject(String.valueOf(userId));
         claims.put(Constants.USER_ROLE, userRole.name());
 
         return Jwts.builder()
                 .setHeaderParam(Header.TYPE, Header.JWT_TYPE)
-                .setSubject(String.valueOf(userId))
                 .setClaims(claims)
                 .setIssuedAt(now)
                 .setExpiration(expireDate)
@@ -52,11 +52,11 @@ public class JwtGenerator {
         final Date expireDate = generateExpirationDate(now, TokenType.REFRESH_TOKEN);
 
         final Claims claims = Jwts.claims();
+        claims.setSubject(String.valueOf(userId));
         claims.put(Constants.USER_ROLE, userRole);
 
         return Jwts.builder()
                 .setHeaderParam(Header.TYPE, Header.JWT_TYPE)
-                .setSubject(String.valueOf(userId))
                 .setClaims(claims)
                 .setIssuedAt(now)
                 .setExpiration(expireDate)

--- a/src/main/java/com/permitseoul/permitserver/auth/jwt/JwtProvider.java
+++ b/src/main/java/com/permitseoul/permitserver/auth/jwt/JwtProvider.java
@@ -7,12 +7,14 @@ import com.permitseoul.permitserver.global.Constants;
 import com.permitseoul.permitserver.user.domain.UserRole;
 import io.jsonwebtoken.*;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.CacheManager;
 import org.springframework.stereotype.Component;
 
 @RequiredArgsConstructor
 @Component
 public class JwtProvider {
     private final JwtGenerator jwtGenerator;
+    private final CacheManager cacheManager;
 
     public Token issueToken(final long userId, final UserRole userRole) {
         return Token.of(
@@ -49,6 +51,11 @@ public class JwtProvider {
     public String extractUserRoleFromToken(final String token) {
         final Jws<Claims> claims = parseToken(token);
         return claims.getBody().get(Constants.USER_ROLE, String.class);
+    }
+
+    public String getRefreshTokenFromCache(final long userId) {
+        return cacheManager.getCache(Constants.REFRESH_TOKEN)
+                .get(userId, String.class);
     }
 
     //토큰 파싱

--- a/src/main/java/com/permitseoul/permitserver/auth/jwt/JwtProvider.java
+++ b/src/main/java/com/permitseoul/permitserver/auth/jwt/JwtProvider.java
@@ -2,11 +2,13 @@ package com.permitseoul.permitserver.auth.jwt;
 
 import com.permitseoul.permitserver.auth.domain.Token;
 import com.permitseoul.permitserver.auth.exception.AuthExpiredJwtException;
+import com.permitseoul.permitserver.auth.exception.AuthRTCacheException;
 import com.permitseoul.permitserver.auth.exception.AuthWrongJwtException;
 import com.permitseoul.permitserver.global.Constants;
 import com.permitseoul.permitserver.user.domain.UserRole;
 import io.jsonwebtoken.*;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
 import org.springframework.stereotype.Component;
 
@@ -54,8 +56,11 @@ public class JwtProvider {
     }
 
     public String getRefreshTokenFromCache(final long userId) {
-        return cacheManager.getCache(Constants.REFRESH_TOKEN)
-                .get(userId, String.class);
+        final Cache cache = cacheManager.getCache(Constants.REFRESH_TOKEN);
+        if (cache == null) {
+            throw new AuthRTCacheException();
+        }
+        return cache.get(userId, String.class);
     }
 
     //토큰 파싱

--- a/src/main/java/com/permitseoul/permitserver/auth/service/AuthService.java
+++ b/src/main/java/com/permitseoul/permitserver/auth/service/AuthService.java
@@ -84,7 +84,7 @@ public class AuthService {
             if (!refreshToken.equals(refreshTokenFromCache)) {
                 throw new PermitUnAuthorizedException(ErrorCode.UNAUTHORIZED_WRONG_RT);
             }
-            final Token newToken = jwtProvider.issueToken(userId, UserRole.USER);
+            final Token newToken = GetJwtToken(userId);
             return TokenDto.of(newToken.getAccessToken(), newToken.getRefreshToken());
         } catch (AuthWrongJwtException e) {
             throw new PermitUnAuthorizedException(ErrorCode.UNAUTHORIZED_WRONG_RT);

--- a/src/main/java/com/permitseoul/permitserver/event/domain/entity/Event.java
+++ b/src/main/java/com/permitseoul/permitserver/event/domain/entity/Event.java
@@ -9,7 +9,7 @@ import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "events")
-@Builder
+@Builder(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @AllArgsConstructor

--- a/src/main/java/com/permitseoul/permitserver/event/domain/entity/Event.java
+++ b/src/main/java/com/permitseoul/permitserver/event/domain/entity/Event.java
@@ -3,11 +3,16 @@ package com.permitseoul.permitserver.event.domain.entity;
 import com.permitseoul.permitserver.event.domain.EventType;
 import com.permitseoul.permitserver.global.domain.BaseTimeEntity;
 import jakarta.persistence.*;
+import lombok.*;
 
 import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "events")
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@AllArgsConstructor
 public class Event extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/permitseoul/permitserver/eventDate/domain/entity/EventDate.java
+++ b/src/main/java/com/permitseoul/permitserver/eventDate/domain/entity/EventDate.java
@@ -8,7 +8,7 @@ import java.time.LocalTime;
 
 @Entity
 @Table(name = "event_dates")
-@Builder
+@Builder(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @AllArgsConstructor

--- a/src/main/java/com/permitseoul/permitserver/eventDate/domain/entity/EventDate.java
+++ b/src/main/java/com/permitseoul/permitserver/eventDate/domain/entity/EventDate.java
@@ -1,12 +1,17 @@
 package com.permitseoul.permitserver.eventDate.domain.entity;
 
 import jakarta.persistence.*;
+import lombok.*;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
 
 @Entity
 @Table(name = "event_dates")
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@AllArgsConstructor
 public class EventDate {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/permitseoul/permitserver/eventImage/domain/entity/EventImage.java
+++ b/src/main/java/com/permitseoul/permitserver/eventImage/domain/entity/EventImage.java
@@ -5,7 +5,7 @@ import lombok.*;
 
 @Entity
 @Table(name = "event_images")
-@Builder
+@Builder(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @AllArgsConstructor

--- a/src/main/java/com/permitseoul/permitserver/eventImage/domain/entity/EventImage.java
+++ b/src/main/java/com/permitseoul/permitserver/eventImage/domain/entity/EventImage.java
@@ -1,9 +1,14 @@
 package com.permitseoul.permitserver.eventImage.domain.entity;
 
 import jakarta.persistence.*;
+import lombok.*;
 
 @Entity
 @Table(name = "event_images")
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@AllArgsConstructor
 public class EventImage {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/permitseoul/permitserver/global/config/SecurityConfig.java
+++ b/src/main/java/com/permitseoul/permitserver/global/config/SecurityConfig.java
@@ -30,6 +30,7 @@ public class SecurityConfig {
             "/actuator/health",
             "/api/users/signup",
             "/api/users/login",
+            "/api/users/reissue",
     };
 
     private static final String[] adminURIList = {

--- a/src/main/java/com/permitseoul/permitserver/global/exception/PermitUnAuthorizedException.java
+++ b/src/main/java/com/permitseoul/permitserver/global/exception/PermitUnAuthorizedException.java
@@ -2,10 +2,19 @@ package com.permitseoul.permitserver.global.exception;
 
 import com.permitseoul.permitserver.global.response.code.ErrorCode;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 @Getter
-@RequiredArgsConstructor
 public class PermitUnAuthorizedException extends PermitBaseException {
     private final ErrorCode errorCode;
+    private final String message; // 선택적 메시지
+
+    public PermitUnAuthorizedException(ErrorCode errorCode) {
+        this.errorCode = errorCode;
+        this.message = null;
+    }
+
+    public PermitUnAuthorizedException(ErrorCode errorCode, String message) {
+        this.errorCode = errorCode;
+        this.message = message;
+    }
 }

--- a/src/main/java/com/permitseoul/permitserver/global/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/permitseoul/permitserver/global/filter/JwtAuthenticationFilter.java
@@ -26,8 +26,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final JwtProvider jwtProvider;
     private final List<String> whiteURIList;
 
-    private static final String ROLE = "ROLE_";
-
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         try {

--- a/src/main/java/com/permitseoul/permitserver/global/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/permitseoul/permitserver/global/filter/JwtAuthenticationFilter.java
@@ -45,7 +45,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     }
 
     private void setAuthentication(final HttpServletRequest request) {
-        final String token = CookieExtractor.getTokenCookie(request).getValue();
+        final String token = CookieExtractor.getTokenCookie(request).getValue(); ///accessToken 쿠키 뽑음
         final long userId = jwtProvider.extractUserIdFromToken(token);
         final String userRole = jwtProvider.extractUserRoleFromToken(token);
         final List<GrantedAuthority> authorities = List.of(new SimpleGrantedAuthority(userRole));

--- a/src/main/java/com/permitseoul/permitserver/global/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/permitseoul/permitserver/global/handler/GlobalExceptionHandler.java
@@ -2,6 +2,8 @@ package com.permitseoul.permitserver.global.handler;
 
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.permitseoul.permitserver.global.exception.PermitApiBaseException;
+import com.permitseoul.permitserver.global.exception.PermitBaseException;
+import com.permitseoul.permitserver.global.exception.PermitUnAuthorizedException;
 import com.permitseoul.permitserver.global.exception.PermitUserNotFoundException;
 import com.permitseoul.permitserver.global.response.ApiResponseUtil;
 import com.permitseoul.permitserver.global.response.BaseResponse;
@@ -30,6 +32,12 @@ import java.util.stream.Collectors;
 @Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
+
+    @ExceptionHandler(PermitUnAuthorizedException.class)
+    public ResponseEntity<BaseResponse<?>> handlePermitUnAuthorizedException(final PermitUnAuthorizedException e) {
+        return ApiResponseUtil.failure(e.getErrorCode());
+    }
+
 
     @ExceptionHandler(PermitApiBaseException.class)
     public ResponseEntity<BaseResponse<?>> handleCakeApiBaseException(final PermitApiBaseException e) {

--- a/src/main/java/com/permitseoul/permitserver/global/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/permitseoul/permitserver/global/handler/GlobalExceptionHandler.java
@@ -18,6 +18,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingRequestCookieException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -166,6 +167,17 @@ public class GlobalExceptionHandler {
     public ResponseEntity<BaseResponse<?>> handleNoHandlerFoundException(final NoHandlerFoundException e) {
         return ApiResponseUtil.failure(ErrorCode.NOT_FOUND_API);
     }
+
+    /**
+     * 404 - MissingRequestCookieException
+     * 발생 이유 : 잘못된 api로 요청했을 때 발생
+     */
+    @ExceptionHandler(MissingRequestCookieException.class)
+    public ResponseEntity<BaseResponse<?>> handleMissingRequestCookieException(final MissingRequestCookieException e) {
+        return ApiResponseUtil.failure(ErrorCode.NOT_FOUND_API);
+    }
+
+
 
     /**
      * 405 - HttpRequestMethodNotSupportedException

--- a/src/main/java/com/permitseoul/permitserver/global/response/code/ErrorCode.java
+++ b/src/main/java/com/permitseoul/permitserver/global/response/code/ErrorCode.java
@@ -42,6 +42,7 @@ public enum ErrorCode implements ApiCode {
     NOT_FOUND_ENTITY(HttpStatus.NOT_FOUND, 40400, "대상을 찾을 수 없습니다."),
     NOT_FOUND_API(HttpStatus.NOT_FOUND, 40401, "잘못된 API입니다."),
     NOT_FOUND_USER(HttpStatus.NOT_FOUND, 40402, "없는 유저입니다."),
+    NOT_FOUND_COOKIE(HttpStatus.NOT_FOUND, 40403, "요청 쿠키가 없습니다."),
 
     /**
      * 405 Method Not Allowed

--- a/src/main/java/com/permitseoul/permitserver/global/response/code/ErrorCode.java
+++ b/src/main/java/com/permitseoul/permitserver/global/response/code/ErrorCode.java
@@ -57,7 +57,11 @@ public enum ErrorCode implements ApiCode {
     /**
      * 500 Internal Server Error
      */
-    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 50000, "서버 내부 오류입니다.");
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 50000, "서버 내부 오류입니다."),
+    INTERNAL_RT_CACHE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 50001, "RT가 캐시에 저장되어 있지 않습니다."),
+
+
+    ;
 
     private final HttpStatus httpStatus;
     private final int code;

--- a/src/main/java/com/permitseoul/permitserver/global/response/code/SuccessCode.java
+++ b/src/main/java/com/permitseoul/permitserver/global/response/code/SuccessCode.java
@@ -16,7 +16,7 @@ public enum SuccessCode implements ApiCode {
     /**
      * 201 Created
      */
-    CREATED(HttpStatus.CREATED, 200100, "요청이 성공했습니다.");
+    CREATED(HttpStatus.CREATED, 20100, "요청이 성공했습니다.");
 
     private final HttpStatus httpStatus;
     private final int code;

--- a/src/main/java/com/permitseoul/permitserver/payment/domain/entity/Payment.java
+++ b/src/main/java/com/permitseoul/permitserver/payment/domain/entity/Payment.java
@@ -10,7 +10,7 @@ import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "payments")
-@Builder
+@Builder(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @AllArgsConstructor

--- a/src/main/java/com/permitseoul/permitserver/payment/domain/entity/Payment.java
+++ b/src/main/java/com/permitseoul/permitserver/payment/domain/entity/Payment.java
@@ -4,11 +4,16 @@ import com.permitseoul.permitserver.global.domain.BaseTimeEntity;
 import com.permitseoul.permitserver.payment.domain.PaymentStatus;
 import com.permitseoul.permitserver.payment.domain.PaymentType;
 import jakarta.persistence.*;
+import lombok.*;
 
 import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "payments")
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@AllArgsConstructor
 public class Payment  extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/permitseoul/permitserver/reservation/domain/entity/Reservation.java
+++ b/src/main/java/com/permitseoul/permitserver/reservation/domain/entity/Reservation.java
@@ -3,9 +3,14 @@ package com.permitseoul.permitserver.reservation.domain.entity;
 import com.permitseoul.permitserver.global.domain.BaseTimeEntity;
 import com.permitseoul.permitserver.reservation.domain.ReservationStatus;
 import jakarta.persistence.*;
+import lombok.*;
 
 @Entity
 @Table(name = "reservations")
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@AllArgsConstructor
 public class Reservation extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/permitseoul/permitserver/reservation/domain/entity/Reservation.java
+++ b/src/main/java/com/permitseoul/permitserver/reservation/domain/entity/Reservation.java
@@ -7,7 +7,7 @@ import lombok.*;
 
 @Entity
 @Table(name = "reservations")
-@Builder
+@Builder(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @AllArgsConstructor

--- a/src/main/java/com/permitseoul/permitserver/ticket/domain/entity/Ticket.java
+++ b/src/main/java/com/permitseoul/permitserver/ticket/domain/entity/Ticket.java
@@ -7,7 +7,7 @@ import lombok.*;
 
 @Entity
 @Table(name = "tickets")
-@Builder
+@Builder(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @AllArgsConstructor

--- a/src/main/java/com/permitseoul/permitserver/ticket/domain/entity/Ticket.java
+++ b/src/main/java/com/permitseoul/permitserver/ticket/domain/entity/Ticket.java
@@ -3,9 +3,14 @@ package com.permitseoul.permitserver.ticket.domain.entity;
 import com.permitseoul.permitserver.global.domain.BaseTimeEntity;
 import com.permitseoul.permitserver.ticket.domain.TicketStatus;
 import jakarta.persistence.*;
+import lombok.*;
 
 @Entity
 @Table(name = "tickets")
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@AllArgsConstructor
 public class Ticket extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/permitseoul/permitserver/user/domain/entity/User.java
+++ b/src/main/java/com/permitseoul/permitserver/user/domain/entity/User.java
@@ -10,7 +10,7 @@ import lombok.*;
 
 @Entity
 @Table(name = "users")
-@Builder
+@Builder(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @AllArgsConstructor

--- a/src/main/java/com/permitseoul/permitserver/user/domain/entity/User.java
+++ b/src/main/java/com/permitseoul/permitserver/user/domain/entity/User.java
@@ -7,7 +7,6 @@ import com.permitseoul.permitserver.user.domain.SocialType;
 import com.permitseoul.permitserver.user.domain.UserRole;
 import jakarta.persistence.*;
 import lombok.*;
-import org.springframework.web.service.annotation.GetExchange;
 
 @Entity
 @Table(name = "users")

--- a/src/main/java/com/permitseoul/permitserver/user/repository/UserRepository.java
+++ b/src/main/java/com/permitseoul/permitserver/user/repository/UserRepository.java
@@ -4,13 +4,14 @@ import com.permitseoul.permitserver.user.domain.SocialType;
 import com.permitseoul.permitserver.user.domain.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
     @Query("SELECT u.userId FROM User u WHERE u.socialType = :socialType AND u.socialId = :socialId")
-    Optional<Long> findUserIdBySocialTypeAndSocialId(final SocialType socialType, final String socialId);
+    Optional<Long> findUserIdBySocialTypeAndSocialId(@Param("socialType")final SocialType socialType, @Param("socialId")final String socialId);
 
     boolean existsBySocialTypeAndSocialId(final SocialType socialType, final String socialId);
 }

--- a/src/test/java/com/permitseoul/permitserver/auth/jwt/JwtGeneratorCacheTest.java
+++ b/src/test/java/com/permitseoul/permitserver/auth/jwt/JwtGeneratorCacheTest.java
@@ -1,12 +1,16 @@
 package com.permitseoul.permitserver.auth.jwt;
 
 import com.permitseoul.permitserver.global.Constants;
+import com.permitseoul.permitserver.global.response.code.ErrorCode;
 import com.permitseoul.permitserver.user.domain.UserRole;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cache.CacheManager;
+
+import java.util.Objects;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -19,10 +23,13 @@ class JwtGeneratorCacheTest {
     @Autowired
     private CacheManager cacheManager;
 
+    @Autowired
+    private JwtProvider jwtProvider;
+
     //테스트 후 캐시 삭제
     @AfterEach
     void tearDown() {
-        cacheManager.getCache(Constants.REFRESH_TOKEN).clear();
+        Objects.requireNonNull(cacheManager.getCache(Constants.REFRESH_TOKEN)).clear();
     }
 
     @Test
@@ -34,9 +41,24 @@ class JwtGeneratorCacheTest {
         String token = jwtGenerator.generateRefreshToken(userId, UserRole.USER);
 
         // then
-        String cachedToken = cacheManager.getCache(Constants.REFRESH_TOKEN)
-                .get(userId, String.class);
+        String cachedToken = jwtProvider.getRefreshTokenFromCache(userId);
 
         assertThat(cachedToken).isEqualTo(token);
     }
+
+    @Test
+    void 캐시에_userId_값이_없으면_null_반환() {
+        // given
+        long nonExistUserId = 999L;
+
+        // when
+        String token = jwtProvider.getRefreshTokenFromCache(nonExistUserId);
+
+        // then
+        Assertions.assertNull(token);
+    }
+
+
+
+
 }

--- a/src/test/java/com/permitseoul/permitserver/auth/jwt/JwtProviderTest.java
+++ b/src/test/java/com/permitseoul/permitserver/auth/jwt/JwtProviderTest.java
@@ -6,6 +6,7 @@ import com.permitseoul.permitserver.auth.exception.AuthWrongJwtException;
 import com.permitseoul.permitserver.user.domain.UserRole;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.cache.CacheManager;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -14,6 +15,7 @@ class JwtProviderTest {
 
     private JwtGenerator jwtGenerator;
     private JwtProvider jwtProvider;
+    private CacheManager cacheManager;
 
 
 
@@ -22,7 +24,7 @@ class JwtProviderTest {
         String secret = "ThisIsASecretKeyForJwtGeneration1234567890";
         JwtProperties jwtProperties = new JwtProperties(secret, 1000 * 60 * 15, 1000 * 60 * 60 * 24 * 7);
         jwtGenerator = new JwtGenerator(jwtProperties);
-        jwtProvider = new JwtProvider(jwtGenerator);
+        jwtProvider = new JwtProvider(jwtGenerator, cacheManager);
     }
 
     @Test
@@ -58,7 +60,7 @@ class JwtProviderTest {
         JwtProperties shortExpireProps = new JwtProperties(secret, 1000, 1000 * 60 * 60 * 24 * 7);
 
         JwtGenerator shortGenerator = new JwtGenerator(shortExpireProps);
-        JwtProvider shortProvider = new JwtProvider(shortGenerator);
+        JwtProvider shortProvider = new JwtProvider(shortGenerator, cacheManager);
 
         String token = shortGenerator.generateAccessToken(1L, UserRole.USER);
 


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
- Resolved: #25

## 👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
AT가 만료되면 RT쿠키에 있는 RT와 캐싱되어있는 RT 비교해서 새로 AT, RT 모두 재발급해준다.
## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- 추후에 유저 테이블에 따로 RT랑 유효기간을 넣어둬야될거같음 (why? 재배포하면 스프링캐시가 날라감..)
-  스프링캐시 쓰는 이유는 현재 단일디비인데 redis까지 쓸 필요 없다고 판단.