### PR TITLE
fix: 쿠키 도메인 설정 변경

### DIFF
--- a/src/main/java/com/permitseoul/permitserver/domain/auth/core/jwt/CookieCreatorUtil.java
+++ b/src/main/java/com/permitseoul/permitserver/domain/auth/core/jwt/CookieCreatorUtil.java
@@ -17,6 +17,7 @@ public class CookieCreatorUtil {
                 .httpOnly(true)
                 .secure(true)
                 .sameSite("None")
+                .domain("api-dev.permitseoul.com")
                 .build();
     }
 
@@ -27,6 +28,7 @@ public class CookieCreatorUtil {
                 .httpOnly(true)
                 .secure(true)
                 .sameSite("None")
+                .domain("api-dev.permitseoul.com")
                 .build();
     }
 
@@ -37,6 +39,7 @@ public class CookieCreatorUtil {
                 .httpOnly(true)
                 .secure(true)
                 .sameSite("None")
+                .domain("api-dev.permitseoul.com")
                 .build();
     }
 
@@ -47,6 +50,7 @@ public class CookieCreatorUtil {
                 .httpOnly(true)
                 .secure(true)
                 .sameSite("None")
+                .domain("api-dev.permitseoul.com")
                 .build();
     }
 }


### PR DESCRIPTION
# 🔥*Pull requests*

## 👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- nginx에서 쿠키 도메인을 변경하려면, 기본적으로 코드단에서 도메인이 설정되어있어야 한다.(nginx 쿠키 도메인 값과 동일시 시켜야됨)
## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
