### PR TITLE
feat: 예약 생성 api 수정(예약 선점 - 티켓 수 동시성 처리) - #54

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,4 +64,8 @@ dependencies {
 
 	//oauth
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+
+	//redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
 }

--- a/src/main/java/com/permitseoul/permitserver/domain/auth/api/service/AuthService.java
+++ b/src/main/java/com/permitseoul/permitserver/domain/auth/api/service/AuthService.java
@@ -140,7 +140,7 @@ public class AuthService {
     }
 
     private void validDuplicatedUserBySocial(final SocialType socialType, final String socialId) {
-        userRetriever.validDuplicateUserBySocial(socialType, socialId);
+        userRetriever.validDuplicatedUserBySocial(socialType, socialId);
     }
 
     private Token GetJwtToken(final long userId) {

--- a/src/main/java/com/permitseoul/permitserver/domain/auth/api/service/AuthService.java
+++ b/src/main/java/com/permitseoul/permitserver/domain/auth/api/service/AuthService.java
@@ -6,6 +6,7 @@ import com.permitseoul.permitserver.domain.auth.api.exception.AuthUnAuthorizedFe
 import com.permitseoul.permitserver.domain.auth.core.domain.Token;
 import com.permitseoul.permitserver.domain.auth.api.dto.TokenDto;
 import com.permitseoul.permitserver.domain.auth.core.dto.UserSocialInfoDto;
+import com.permitseoul.permitserver.domain.user.core.exception.UserDuplicateException;
 import com.permitseoul.permitserver.domain.auth.core.exception.AuthFeignException;
 import com.permitseoul.permitserver.domain.auth.core.exception.AuthRTCacheException;
 import com.permitseoul.permitserver.domain.auth.core.exception.AuthWrongJwtException;
@@ -20,7 +21,6 @@ import com.permitseoul.permitserver.domain.user.core.domain.Gender;
 import com.permitseoul.permitserver.domain.user.core.domain.SocialType;
 import com.permitseoul.permitserver.domain.user.core.domain.UserRole;
 import com.permitseoul.permitserver.domain.user.core.domain.entity.UserEntity;
-import com.permitseoul.permitserver.domain.user.core.exception.UserExistException;
 import com.permitseoul.permitserver.domain.user.core.exception.UserNotFoundException;
 import io.jsonwebtoken.ExpiredJwtException;
 import lombok.RequiredArgsConstructor;
@@ -48,13 +48,13 @@ public class AuthService {
                            final String socialAccessToken) {
         try {
             final String userSocialId = getUserSocialId(socialType, socialAccessToken);
-            isUserExist(socialType, userSocialId);
+            validDuplicatedUserBySocial(socialType, userSocialId);
             final UserEntity newUserEntity = createUser(userName, userAge, userGender, userEmail, userSocialId, socialType);
             final Token newToken = GetJwtToken(newUserEntity.getUserId());
             return TokenDto.of(newToken.getAccessToken(), newToken.getRefreshToken());
         } catch (AuthFeignException e) {
             throw new AuthUnAuthorizedFeignException(ErrorCode.UNAUTHORIZED_FEIGN, e.getMessage());
-        } catch (UserExistException e ) {
+        } catch (UserDuplicateException e ) {
             throw new AuthUnAuthorizedException(ErrorCode.CONFLICT);
         }
     }
@@ -139,8 +139,8 @@ public class AuthService {
         return userRetriever.getUserIdBySocialInfo(socialType, socialId);
     }
 
-    private void isUserExist(final SocialType socialType, final String socialId) {
-        userRetriever.isExistUserBySocial(socialType, socialId);
+    private void validDuplicatedUserBySocial(final SocialType socialType, final String socialId) {
+        userRetriever.validDuplicateUserBySocial(socialType, socialId);
     }
 
     private Token GetJwtToken(final long userId) {

--- a/src/main/java/com/permitseoul/permitserver/domain/auth/core/jwt/CookieCreatorUtil.java
+++ b/src/main/java/com/permitseoul/permitserver/domain/auth/core/jwt/CookieCreatorUtil.java
@@ -9,7 +9,7 @@ import org.springframework.http.ResponseCookie;
 public class CookieCreatorUtil {
     private static final long AT_MAX_AGE = 365L * 24 * 60 * 60 * 1000; // todo: 추후 변경
     private static final long RT_MAX_AGE = 369L * 24 * 60 * 60 * 1000; // todo: 추후 변경
-    private static final long RESERVED_MAX_AGE = 10L * 60 * 1000; // 10분(10분간 선점 가능)
+    private static final long RESERVED_MAX_AGE = 10L * 60; // 10분(10분간 선점 가능)
     private static final String SESSION_NAME = "sessionKey";
 
     public static ResponseCookie createReservationSessionCookie(final String sessionKey) {

--- a/src/main/java/com/permitseoul/permitserver/domain/auth/core/jwt/CookieCreatorUtil.java
+++ b/src/main/java/com/permitseoul/permitserver/domain/auth/core/jwt/CookieCreatorUtil.java
@@ -9,6 +9,18 @@ import org.springframework.http.ResponseCookie;
 public class CookieCreatorUtil {
     private static final long AT_MAX_AGE = 365L * 24 * 60 * 60 * 1000; // todo: 추후 변경
     private static final long RT_MAX_AGE = 369L * 24 * 60 * 60 * 1000; // todo: 추후 변경
+    private static final long RESERVED_MAX_AGE = 10L * 60 * 1000; // 10분(10분간 선점 가능)
+    private static final String SESSION_NAME = "sessionKey";
+
+    public static ResponseCookie createReservationSessionCookie(final String sessionKey) {
+        return ResponseCookie.from(SESSION_NAME, sessionKey)
+                .maxAge(RESERVED_MAX_AGE)
+                .path("/")
+                .httpOnly(true)
+                .secure(true)
+                .sameSite("None")
+                .build();
+    }
 
     public static ResponseCookie createAccessTokenCookie(final String accessToken) {
         return ResponseCookie.from(Constants.ACCESS_TOKEN, accessToken)

--- a/src/main/java/com/permitseoul/permitserver/domain/event/core/component/EventRetriever.java
+++ b/src/main/java/com/permitseoul/permitserver/domain/event/core/component/EventRetriever.java
@@ -22,7 +22,7 @@ public class EventRetriever {
     }
 
     @Transactional(readOnly = true)
-    public void isExistByEventId(final long eventId) {
+    public void validExistEventById(final long eventId) {
         if(!eventRepository.existsById(eventId)) {
             throw new EventNotfoundException();
         }

--- a/src/main/java/com/permitseoul/permitserver/domain/event/core/domain/Event.java
+++ b/src/main/java/com/permitseoul/permitserver/domain/event/core/domain/Event.java
@@ -18,7 +18,7 @@ public class Event {
     private final String lineUp;
     private final String details;
     private final Integer minAge;
-    private final boolean isActive;
+    private final LocalDateTime visibleEndDate;
     private final String ticketCheckCode;
     private final LocalDateTime visibleStartDate;
 
@@ -33,7 +33,7 @@ public class Event {
                 entity.getLineUp(),
                 entity.getDetails(),
                 entity.getMinAge(),
-                entity.isActive(),
+                entity.getVisibleEndDate(),
                 entity.getTicketCheckCode(),
                 entity.getVisibleStartDate()
         );

--- a/src/main/java/com/permitseoul/permitserver/domain/event/core/domain/entity/EventEntity.java
+++ b/src/main/java/com/permitseoul/permitserver/domain/event/core/domain/entity/EventEntity.java
@@ -25,10 +25,10 @@ public class EventEntity extends BaseTimeEntity {
     private EventType eventType;
 
     @Column(name = "start_date", nullable = false)
-    private LocalDateTime startDate; //2025.11.20 15:40
+    private LocalDateTime startDate;
 
     @Column(name = "end_date", nullable = false)
-    private LocalDateTime endDate; //2025.11.20 15:40
+    private LocalDateTime endDate;
 
     @Column(name = "venue", nullable = false)
     private String venue;
@@ -42,8 +42,8 @@ public class EventEntity extends BaseTimeEntity {
     @Column(name = "min_age")
     private Integer minAge;
 
-    @Column(name = "is_active", nullable = false)
-    private boolean isActive;
+    @Column(name = "visible_end_date", nullable = false)
+    private LocalDateTime visibleEndDate;
 
     @Column(name = "ticket_check_code", length = 10, nullable = false)
     private String ticketCheckCode;
@@ -59,7 +59,7 @@ public class EventEntity extends BaseTimeEntity {
                         String lineUp,
                         String details,
                         Integer minAge,
-                        boolean isActive,
+                        LocalDateTime visibleEndDate,
                         String ticketCheckCode,
                         LocalDateTime visibleStartDate) {
         this.name = name;
@@ -70,7 +70,7 @@ public class EventEntity extends BaseTimeEntity {
         this.lineUp = lineUp;
         this.details = details;
         this.minAge = minAge;
-        this.isActive = isActive;
+        this.visibleEndDate = visibleEndDate;
         this.ticketCheckCode = ticketCheckCode;
         this.visibleStartDate = visibleStartDate;
     }

--- a/src/main/java/com/permitseoul/permitserver/domain/event/core/domain/entity/EventEntity.java
+++ b/src/main/java/com/permitseoul/permitserver/domain/event/core/domain/entity/EventEntity.java
@@ -45,7 +45,7 @@ public class EventEntity extends BaseTimeEntity {
     @Column(name = "visible_end_date", nullable = false)
     private LocalDateTime visibleEndDate;
 
-    @Column(name = "ticket_check_code", length = 10, nullable = false)
+    @Column(name = "ticket_check_code", length = 30, nullable = false)
     private String ticketCheckCode;
 
     @Column(name = "visible_start_date")

--- a/src/main/java/com/permitseoul/permitserver/domain/payment/api/PaymentExceptionHandler.java
+++ b/src/main/java/com/permitseoul/permitserver/domain/payment/api/PaymentExceptionHandler.java
@@ -1,0 +1,18 @@
+package com.permitseoul.permitserver.domain.payment.api;
+
+import com.permitseoul.permitserver.domain.payment.api.exception.PaymentApiException;
+import com.permitseoul.permitserver.domain.reservation.api.exception.ReservationApiException;
+import com.permitseoul.permitserver.global.response.ApiResponseUtil;
+import com.permitseoul.permitserver.global.response.BaseResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice(basePackages = "com.permitseoul.permitserver.domain.payment")
+public class PaymentExceptionHandler {
+
+    @ExceptionHandler(PaymentApiException.class)
+    public ResponseEntity<BaseResponse<?>> handlePaymentApiException(final PaymentApiException e) {
+        return ApiResponseUtil.failure(e.getErrorCode());
+    }
+}

--- a/src/main/java/com/permitseoul/permitserver/domain/payment/api/exception/PaymentApiException.java
+++ b/src/main/java/com/permitseoul/permitserver/domain/payment/api/exception/PaymentApiException.java
@@ -1,0 +1,12 @@
+package com.permitseoul.permitserver.domain.payment.api.exception;
+
+import com.permitseoul.permitserver.domain.payment.PaymentBaseException;
+import com.permitseoul.permitserver.global.response.code.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public abstract class PaymentApiException extends PaymentBaseException {
+  private final ErrorCode errorCode;
+}

--- a/src/main/java/com/permitseoul/permitserver/domain/payment/api/service/PaymentService.java
+++ b/src/main/java/com/permitseoul/permitserver/domain/payment/api/service/PaymentService.java
@@ -13,7 +13,6 @@ import com.permitseoul.permitserver.domain.payment.api.dto.TossConfirmErrorRespo
 import com.permitseoul.permitserver.domain.payment.core.component.PaymentRetriever;
 import com.permitseoul.permitserver.domain.payment.core.component.PaymentSaver;
 import com.permitseoul.permitserver.domain.payment.core.domain.Currency;
-import com.permitseoul.permitserver.domain.payment.core.domain.Payment;
 import com.permitseoul.permitserver.domain.payment.core.domain.entity.PaymentEntity;
 import com.permitseoul.permitserver.domain.payment.core.exception.PaymentNotFoundException;
 import com.permitseoul.permitserver.domain.paymentcancel.core.component.PaymentCancelSaver;
@@ -23,7 +22,6 @@ import com.permitseoul.permitserver.domain.payment.api.dto.PaymentConfirmRespons
 import com.permitseoul.permitserver.domain.reservation.api.exception.*;
 import com.permitseoul.permitserver.domain.reservation.core.component.ReservationRetriever;
 import com.permitseoul.permitserver.domain.reservation.core.component.ReservationUpdater;
-import com.permitseoul.permitserver.domain.reservation.core.domain.Reservation;
 import com.permitseoul.permitserver.domain.reservation.core.domain.ReservationStatus;
 import com.permitseoul.permitserver.domain.reservation.core.domain.entity.ReservationEntity;
 import com.permitseoul.permitserver.domain.reservation.core.exception.ReservationNotFoundException;
@@ -175,7 +173,7 @@ public class PaymentService {
 
             updateTicketStatus(ticketEntity, TicketStatus.CANCELED);
             updateReservationStatus(reservationEntity, ReservationStatus.PAYMENT_CANCELED);
-            increaseTicketTypeCount(reservationTicketList);
+            increaseRedisTicketTypeCount(reservationTicketList);
 
             final PaymentCancelResponse.CancelDetail latestCancelPayment = DateFormatterUtil.getLatestCancelPaymentByDate(paymentCancelResponse.cancels()).orElseThrow(
                     () -> new DateFormatException(ErrorCode.INTERNAL_ISO_DATE_ERROR)
@@ -196,7 +194,7 @@ public class PaymentService {
         }
     }
 
-    private void increaseTicketTypeCount(final List<ReservationTicket> reservationTicketList) {
+    private void increaseRedisTicketTypeCount(final List<ReservationTicket> reservationTicketList) {
         reservationTicketList.forEach(
                 reservationTicket -> {
                     final TicketTypeEntity ticketTypeEntity = ticketTypeRetriever.findTicketTypeEntityById(reservationTicket.getTicketTypeId());

--- a/src/main/java/com/permitseoul/permitserver/domain/reservation/api/dto/ReservationInfoRequest.java
+++ b/src/main/java/com/permitseoul/permitserver/domain/reservation/api/dto/ReservationInfoRequest.java
@@ -3,6 +3,7 @@ package com.permitseoul.permitserver.domain.reservation.api.dto;
 import jakarta.annotation.Nullable;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 
 import java.math.BigDecimal;
@@ -23,6 +24,7 @@ public record ReservationInfoRequest(
         String orderId,
 
         @Valid
+        @NotNull
         List<TicketTypeInfo> ticketTypeInfos
 ) {
     public record TicketTypeInfo(

--- a/src/main/java/com/permitseoul/permitserver/domain/reservation/api/exception/ExpiredReservationException.java
+++ b/src/main/java/com/permitseoul/permitserver/domain/reservation/api/exception/ExpiredReservationException.java
@@ -1,0 +1,9 @@
+package com.permitseoul.permitserver.domain.reservation.api.exception;
+
+import com.permitseoul.permitserver.global.response.code.ErrorCode;
+
+public class ExpiredReservationException extends ReservationApiException {
+    public ExpiredReservationException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/permitseoul/permitserver/domain/reservation/api/exception/InSufficientReservationException.java
+++ b/src/main/java/com/permitseoul/permitserver/domain/reservation/api/exception/InSufficientReservationException.java
@@ -1,0 +1,9 @@
+package com.permitseoul.permitserver.domain.reservation.api.exception;
+
+import com.permitseoul.permitserver.global.response.code.ErrorCode;
+
+public class InSufficientReservationException extends ReservationApiException {
+    public InSufficientReservationException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/permitseoul/permitserver/domain/reservation/api/exception/RedisInSufficientTicketException.java
+++ b/src/main/java/com/permitseoul/permitserver/domain/reservation/api/exception/RedisInSufficientTicketException.java
@@ -1,0 +1,6 @@
+package com.permitseoul.permitserver.domain.reservation.api.exception;
+
+import com.permitseoul.permitserver.domain.reservation.ReservationBaseException;
+
+public class RedisInSufficientTicketException extends ReservationBaseException {
+}

--- a/src/main/java/com/permitseoul/permitserver/domain/reservation/api/exception/ReservationBadRequestException.java
+++ b/src/main/java/com/permitseoul/permitserver/domain/reservation/api/exception/ReservationBadRequestException.java
@@ -1,0 +1,9 @@
+package com.permitseoul.permitserver.domain.reservation.api.exception;
+
+import com.permitseoul.permitserver.global.response.code.ErrorCode;
+
+public class ReservationBadRequestException extends ReservationApiException {
+    public ReservationBadRequestException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/permitseoul/permitserver/domain/reservation/api/service/ReservationService.java
+++ b/src/main/java/com/permitseoul/permitserver/domain/reservation/api/service/ReservationService.java
@@ -159,11 +159,7 @@ public class ReservationService {
 
             return requestTicketTypeInfoMap;
         } catch (RedisInSufficientTicketException e) { //개수 부족하면 redis 롤백 처리
-            requestTicketTypeInfoMap.forEach(
-                    (requestTicketTypeId, count) -> {
-                        final String redisKey = REDIS_TICKET_TYPE_KEY_NAME + requestTicketTypeId + REDIS_TICKET_TYPE_REMAIN;
-                        redisTemplate.opsForValue().increment(redisKey, count);
-                    });
+            increaseRedisTicketCount(requestTicketTypeInfoMap);
             throw new TicketTypeInsufficientCountException();
         }
     }

--- a/src/main/java/com/permitseoul/permitserver/domain/reservation/api/service/ReservationService.java
+++ b/src/main/java/com/permitseoul/permitserver/domain/reservation/api/service/ReservationService.java
@@ -8,25 +8,36 @@ import com.permitseoul.permitserver.domain.event.core.domain.Event;
 import com.permitseoul.permitserver.domain.event.core.exception.EventNotfoundException;
 import com.permitseoul.permitserver.domain.reservation.api.dto.ReservationInfoRequest;
 import com.permitseoul.permitserver.domain.reservation.api.dto.ReservationInfoResponse;
-import com.permitseoul.permitserver.domain.reservation.api.exception.ConflictReservationException;
-import com.permitseoul.permitserver.domain.reservation.api.exception.NotfoundReservationException;
-import com.permitseoul.permitserver.domain.reservation.api.exception.ReservationBadRequestException;
+import com.permitseoul.permitserver.domain.reservation.api.exception.*;
+import com.permitseoul.permitserver.domain.reservation.core.component.ReservationAndReservationTicketFacade;
 import com.permitseoul.permitserver.domain.reservation.core.component.ReservationRetriever;
 import com.permitseoul.permitserver.domain.reservation.core.component.ReservationSaver;
 import com.permitseoul.permitserver.domain.reservation.core.domain.Reservation;
 import com.permitseoul.permitserver.domain.reservation.core.exception.ReservationNotFoundException;
 import com.permitseoul.permitserver.domain.reservationticket.core.component.ReservationTicketSaver;
+import com.permitseoul.permitserver.domain.ticketround.core.component.TicketRoundRetriever;
+import com.permitseoul.permitserver.domain.ticketround.core.domain.entity.TicketRoundEntity;
+import com.permitseoul.permitserver.domain.ticketround.core.exception.TicketRoundExpiredException;
+import com.permitseoul.permitserver.domain.ticketround.core.exception.TicketRoundNotFoundException;
 import com.permitseoul.permitserver.domain.tickettype.core.component.TicketTypeRetriever;
+import com.permitseoul.permitserver.domain.tickettype.core.domain.TicketType;
+import com.permitseoul.permitserver.domain.tickettype.core.domain.entity.TicketTypeEntity;
+import com.permitseoul.permitserver.domain.tickettype.core.exception.TicketTypeInsufficientCountException;
 import com.permitseoul.permitserver.domain.user.core.component.UserRetriever;
 import com.permitseoul.permitserver.domain.user.core.domain.User;
 import com.permitseoul.permitserver.domain.user.core.exception.UserNotFoundException;
 import com.permitseoul.permitserver.global.response.code.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -39,34 +50,46 @@ public class ReservationService {
     private final TicketTypeRetriever ticketTypeRetriever;
     private final CouponRetriever couponRetriever;
     private final ReservationRetriever reservationRetriever;
+    private final TicketRoundRetriever ticketRoundRetriever;
+    private final RedisTemplate<String, String> redisTemplate;
+    private final ReservationAndReservationTicketFacade reservationAndReservationTicketFacade;
 
-    @Transactional
+    private static final String REDIS_TICKET_TYPE_KEY_NAME = "ticket_type:";
+    private static final String REDIS_TICKET_TYPE_REMAIN = ":remain";
+
+
+
+    // request 값들 검증
+    // redis로 ticketTypeInfos에 있는 티켓 타입의 개수만큼 redis 재고에 있는지 확인 -> 있으면 redis 재고 티켓타입 id별로 티켓 count만큼 descBy 사용해서 재고 감소시킴
+    // 그런 후에 예약테이블 및 예약티켓 생성
     public String saveReservation(final long userId,
                                   final long eventId,
                                   final String couponCode,
                                   final BigDecimal totalAmount,
                                   final String orderId,
-                                  final List<ReservationInfoRequest.TicketTypeInfo> ticketTypeInfos) {
-        // request 값들 검증
-        // redis로 ticketTypeInfos에 있는 티켓 타입의 개수만큼 redis 재고에 있는지 확인 -> 있으면 redis 재고 티켓타입 id별로 티켓 count만큼 descBy 사용해서 재고 감소시킴
-        // 그런 후에 예약테이블 및 예약티켓 생성
-
-        
+                                  final List<ReservationInfoRequest.TicketTypeInfo> requestTicketTypeInfos) {
 
         try {
             validExistUserById(userId);
             validExistEventById(eventId);
-            validExistTicketType(ticketTypeInfos);
+            validUsableTicketType(requestTicketTypeInfos);
             if(couponCode != null) {
-                validateCouponCode(couponCode, ticketTypeInfos);
+                validateCouponCode(couponCode, requestTicketTypeInfos);
             }
 
+            //redis로 선점 예약 방식 (10분)
+            decreaseRedisTicketCount(requestTicketTypeInfos);
+
             //여기서 터지는 dataintegrationException은 글로벌 핸들러에서 잡고있음.
-            final Reservation reservation = reservationSaver.saveReservation(userId, eventId, orderId, totalAmount, couponCode);
-            ticketTypeInfos.forEach(
-                    ticketTypeInfo -> reservationTicketSaver.saveReservationTicket(ticketTypeInfo.id(), reservation.getOrderId(), ticketTypeInfo.count())
+            final String savedReservationOrderId =  reservationAndReservationTicketFacade.saveReservationWithTicket(
+                    userId,
+                    eventId,
+                    orderId,
+                    totalAmount,
+                    couponCode,
+                    requestTicketTypeInfos
             );
-            return reservation.getOrderId();
+            return savedReservationOrderId;
         } catch (EventNotfoundException e) {
             throw new NotfoundReservationException(ErrorCode.NOT_FOUND_EVENT);
         } catch (UserNotFoundException e) {
@@ -75,6 +98,34 @@ public class ReservationService {
             throw new NotfoundReservationException(ErrorCode.NOT_FOUND_COUPON_CODE);
         } catch (CouponConflictException e) {
             throw new ConflictReservationException(ErrorCode.CONFLICT_ALREADY_USED_COUPON_CODE);
+        } catch (TicketRoundExpiredException e) {
+            throw new ExpiredReservationException(ErrorCode.BAD_REQUEST_TICKET_SALES_EXPIRED);
+        } catch (TicketRoundNotFoundException e) {
+            throw new NotfoundReservationException(ErrorCode.NOT_FOUND_TICKET_ROUND);
+        } catch (TicketTypeInsufficientCountException e) {
+            throw new InSufficientReservationException(ErrorCode.CONFLICT_INSUFFICIENT_TICKET);
+        }
+    }
+
+    private void decreaseRedisTicketCount(final List<ReservationInfoRequest.TicketTypeInfo> requestTicketTypeInfos) {
+        final Map<Long, Integer> decrementedStock = new HashMap<>();
+        try {
+            for (ReservationInfoRequest.TicketTypeInfo requestTicketType : requestTicketTypeInfos) {
+                final String redisKey = REDIS_TICKET_TYPE_KEY_NAME + requestTicketType.id() + REDIS_TICKET_TYPE_REMAIN;
+                final Long remain = redisTemplate.opsForValue().decrement(redisKey, requestTicketType.count());
+                if (remain == null || remain < 0) {
+                    decrementedStock.put(requestTicketType.id(), requestTicketType.count());
+                    throw new RedisInSufficientTicketException();
+                }
+
+
+            }
+        } catch (RedisInSufficientTicketException e) {
+            decrementedStock.forEach((requestTicketTypeId, count) -> {
+                final String redisKey = REDIS_TICKET_TYPE_KEY_NAME + requestTicketTypeId + REDIS_TICKET_TYPE_REMAIN;
+                redisTemplate.opsForValue().increment(redisKey, count);
+            });
+            throw new TicketTypeInsufficientCountException();
         }
     }
 
@@ -110,9 +161,19 @@ public class ReservationService {
         eventRetriever.validExistEventById(eventId);
     }
 
-    private void validExistTicketType(final List<ReservationInfoRequest.TicketTypeInfo> ticketTypeInfos) {
-        ticketTypeInfos.forEach(
-                ticketType -> ticketTypeRetriever.validExistTicketType(ticketType.id())
+    private void validUsableTicketType(final List<ReservationInfoRequest.TicketTypeInfo> requestTicketTypeInfos) {
+        final Map<Long, Integer> ticketCountMap = requestTicketTypeInfos.stream()
+                .collect(Collectors.toMap(ReservationInfoRequest.TicketTypeInfo::id, ReservationInfoRequest.TicketTypeInfo::count));
+
+        ticketCountMap.forEach((ticketTypeId, requestedCount) -> {
+                    final TicketTypeEntity ticketType = ticketTypeRetriever.findTicketTypeEntityById(ticketTypeId);
+                    // 티켓 개수 검증
+                    ticketType.verifyTicketCount(requestedCount);
+                    //티켓 구매가능 날짜 검증
+                    final TicketRoundEntity ticketRound = ticketRoundRetriever.findTicketRoundEntityById(ticketType.getTicketRoundId());
+                    final LocalDateTime now = LocalDateTime.now();
+                    ticketRound.verifyTicketSalesAvailable(now);
+                }
         );
     }
 

--- a/src/main/java/com/permitseoul/permitserver/domain/reservation/core/component/ReservationAndReservationTicketFacade.java
+++ b/src/main/java/com/permitseoul/permitserver/domain/reservation/core/component/ReservationAndReservationTicketFacade.java
@@ -2,6 +2,8 @@ package com.permitseoul.permitserver.domain.reservation.core.component;
 
 import com.permitseoul.permitserver.domain.reservation.api.dto.ReservationInfoRequest;
 import com.permitseoul.permitserver.domain.reservation.core.domain.Reservation;
+import com.permitseoul.permitserver.domain.reservationsession.core.component.ReservationSessionSaver;
+import com.permitseoul.permitserver.domain.reservationsession.core.domain.ReservationSession;
 import com.permitseoul.permitserver.domain.reservationticket.core.component.ReservationTicketSaver;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -9,6 +11,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
 import java.util.List;
+import java.util.UUID;
 
 @Component
 @RequiredArgsConstructor
@@ -16,18 +19,23 @@ public class ReservationAndReservationTicketFacade {
 
     private final ReservationSaver reservationSaver;
     private final ReservationTicketSaver reservationTicketSaver;
+    private final ReservationSessionSaver reservationSessionSaver;
 
     @Transactional
-    public String saveReservationWithTicket(final long userId,
-                                          final long eventId,
-                                          final String orderId,
-                                          final BigDecimal totalAmount,
-                                          final String couponCode,
-                                          final List<ReservationInfoRequest.TicketTypeInfo> requestTicketTypeInfos) {
+    public String saveReservationWithTicketAndSessionKey(final long userId,
+                                                         final long eventId,
+                                                         final String orderId,
+                                                         final BigDecimal totalAmount,
+                                                         final String couponCode,
+                                                         final List<ReservationInfoRequest.TicketTypeInfo> requestTicketTypeInfos) {
         final Reservation reservation = reservationSaver.saveReservation(userId, eventId, orderId, totalAmount, couponCode);
         requestTicketTypeInfos.forEach(
                 ticketTypeInfo -> reservationTicketSaver.saveReservationTicket(ticketTypeInfo.id(), reservation.getOrderId(), ticketTypeInfo.count())
         );
-        return reservation.getOrderId();
+
+        //세션 생성
+        final String sessionKey = UUID.randomUUID().toString();
+        final ReservationSession reservationSession = reservationSessionSaver.saveReservationSession(userId, orderId, sessionKey);
+        return reservationSession.getSessionKey();
     }
 }

--- a/src/main/java/com/permitseoul/permitserver/domain/reservation/core/component/ReservationAndReservationTicketFacade.java
+++ b/src/main/java/com/permitseoul/permitserver/domain/reservation/core/component/ReservationAndReservationTicketFacade.java
@@ -1,0 +1,33 @@
+package com.permitseoul.permitserver.domain.reservation.core.component;
+
+import com.permitseoul.permitserver.domain.reservation.api.dto.ReservationInfoRequest;
+import com.permitseoul.permitserver.domain.reservation.core.domain.Reservation;
+import com.permitseoul.permitserver.domain.reservationticket.core.component.ReservationTicketSaver;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class ReservationAndReservationTicketFacade {
+
+    private final ReservationSaver reservationSaver;
+    private final ReservationTicketSaver reservationTicketSaver;
+
+    @Transactional
+    public String saveReservationWithTicket(final long userId,
+                                          final long eventId,
+                                          final String orderId,
+                                          final BigDecimal totalAmount,
+                                          final String couponCode,
+                                          final List<ReservationInfoRequest.TicketTypeInfo> requestTicketTypeInfos) {
+        final Reservation reservation = reservationSaver.saveReservation(userId, eventId, orderId, totalAmount, couponCode);
+        requestTicketTypeInfos.forEach(
+                ticketTypeInfo -> reservationTicketSaver.saveReservationTicket(ticketTypeInfo.id(), reservation.getOrderId(), ticketTypeInfo.count())
+        );
+        return reservation.getOrderId();
+    }
+}

--- a/src/main/java/com/permitseoul/permitserver/domain/reservation/core/component/ReservationSaver.java
+++ b/src/main/java/com/permitseoul/permitserver/domain/reservation/core/component/ReservationSaver.java
@@ -5,6 +5,7 @@ import com.permitseoul.permitserver.domain.reservation.core.domain.entity.Reserv
 import com.permitseoul.permitserver.domain.reservation.core.repository.ReservationRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
 

--- a/src/main/java/com/permitseoul/permitserver/domain/reservation/core/component/ReservationSaver.java
+++ b/src/main/java/com/permitseoul/permitserver/domain/reservation/core/component/ReservationSaver.java
@@ -5,7 +5,6 @@ import com.permitseoul.permitserver.domain.reservation.core.domain.entity.Reserv
 import com.permitseoul.permitserver.domain.reservation.core.repository.ReservationRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
 

--- a/src/main/java/com/permitseoul/permitserver/domain/reservationsession/core/component/ReservationSessionSaver.java
+++ b/src/main/java/com/permitseoul/permitserver/domain/reservationsession/core/component/ReservationSessionSaver.java
@@ -1,0 +1,21 @@
+package com.permitseoul.permitserver.domain.reservationsession.core.component;
+
+import com.permitseoul.permitserver.domain.reservationsession.core.domain.ReservationSession;
+import com.permitseoul.permitserver.domain.reservationsession.core.domain.entity.ReservationSessionEntity;
+import com.permitseoul.permitserver.domain.reservationsession.core.repository.ReservationSessionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ReservationSessionSaver {
+
+    private final ReservationSessionRepository reservationSessionRepository;
+
+    public ReservationSession saveReservationSession(final long userId,
+                                                     final String orderId,
+                                                     final String sessionKey) {
+        final ReservationSessionEntity reservationSession = reservationSessionRepository.save(ReservationSessionEntity.create(userId, orderId, sessionKey));
+        return ReservationSession.fromEntity(reservationSession);
+    }
+}

--- a/src/main/java/com/permitseoul/permitserver/domain/reservationsession/core/domain/ReservationSession.java
+++ b/src/main/java/com/permitseoul/permitserver/domain/reservationsession/core/domain/ReservationSession.java
@@ -1,0 +1,23 @@
+package com.permitseoul.permitserver.domain.reservationsession.core.domain;
+
+import com.permitseoul.permitserver.domain.reservationsession.core.domain.entity.ReservationSessionEntity;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public class ReservationSession {
+    private final Long reservationSessionsId;
+    private final long userId;
+    private final String orderId;
+    private final String sessionKey;
+
+    public static ReservationSession fromEntity(ReservationSessionEntity reservationSessionEntity) {
+        return new ReservationSession(
+                reservationSessionEntity.getReservationSessionsId(),
+                reservationSessionEntity.getUserId(),
+                reservationSessionEntity.getOrderId(),
+                reservationSessionEntity.getSessionKey()
+        );
+    }
+}

--- a/src/main/java/com/permitseoul/permitserver/domain/reservationsession/core/domain/entity/ReservationSessionEntity.java
+++ b/src/main/java/com/permitseoul/permitserver/domain/reservationsession/core/domain/entity/ReservationSessionEntity.java
@@ -1,0 +1,38 @@
+package com.permitseoul.permitserver.domain.reservationsession.core.domain.entity;
+
+import com.permitseoul.permitserver.global.domain.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+@Entity
+@Table(name = "reservation_sessions")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ReservationSessionEntity extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "reservation_sessions_id", nullable = false)
+    private Long reservationSessionsId;
+
+    @Column(name = "user_id", nullable = false)
+    private long userId;
+
+    @Column(name = "order_id", nullable = false, length = 64)
+    private String orderId;
+
+    @Column(name = "session_key", nullable = false)
+    private String sessionKey;
+
+    private ReservationSessionEntity(long userId, String orderId, String sessionKey) {
+        this.userId = userId;
+        this.orderId = orderId;
+        this.sessionKey = sessionKey;
+    }
+
+    public static ReservationSessionEntity create(long userId, String orderId, String sessionKey) {
+        return new ReservationSessionEntity(userId, orderId, sessionKey);
+    }
+}

--- a/src/main/java/com/permitseoul/permitserver/domain/reservationsession/core/repository/ReservationSessionRepository.java
+++ b/src/main/java/com/permitseoul/permitserver/domain/reservationsession/core/repository/ReservationSessionRepository.java
@@ -1,0 +1,9 @@
+package com.permitseoul.permitserver.domain.reservationsession.core.repository;
+
+import com.permitseoul.permitserver.domain.reservationsession.core.domain.entity.ReservationSessionEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ReservationSessionRepository extends JpaRepository<ReservationSessionEntity, Long> {
+}

--- a/src/main/java/com/permitseoul/permitserver/domain/ticketround/TicketRoundBaseException.java
+++ b/src/main/java/com/permitseoul/permitserver/domain/ticketround/TicketRoundBaseException.java
@@ -1,0 +1,4 @@
+package com.permitseoul.permitserver.domain.ticketround;
+
+public abstract class TicketRoundBaseException extends RuntimeException {
+}

--- a/src/main/java/com/permitseoul/permitserver/domain/ticketround/core/component/TicketRoundRetriever.java
+++ b/src/main/java/com/permitseoul/permitserver/domain/ticketround/core/component/TicketRoundRetriever.java
@@ -5,12 +5,14 @@ import com.permitseoul.permitserver.domain.ticketround.core.exception.TicketRoun
 import com.permitseoul.permitserver.domain.ticketround.core.repository.TicketRoundRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 @Component
 @RequiredArgsConstructor
 public class TicketRoundRetriever {
     private final TicketRoundRepository ticketRoundRepository;
 
+    @Transactional(readOnly = true)
     public TicketRoundEntity findTicketRoundEntityById(final long ticketRoundId) {
         return ticketRoundRepository.findById(ticketRoundId).orElseThrow(TicketRoundNotFoundException::new);
     }

--- a/src/main/java/com/permitseoul/permitserver/domain/ticketround/core/component/TicketRoundRetriever.java
+++ b/src/main/java/com/permitseoul/permitserver/domain/ticketround/core/component/TicketRoundRetriever.java
@@ -1,0 +1,17 @@
+package com.permitseoul.permitserver.domain.ticketround.core.component;
+
+import com.permitseoul.permitserver.domain.ticketround.core.domain.entity.TicketRoundEntity;
+import com.permitseoul.permitserver.domain.ticketround.core.exception.TicketRoundNotFoundException;
+import com.permitseoul.permitserver.domain.ticketround.core.repository.TicketRoundRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class TicketRoundRetriever {
+    private final TicketRoundRepository ticketRoundRepository;
+
+    public TicketRoundEntity findTicketRoundEntityById(final long ticketRoundId) {
+        return ticketRoundRepository.findById(ticketRoundId).orElseThrow(TicketRoundNotFoundException::new);
+    }
+}

--- a/src/main/java/com/permitseoul/permitserver/domain/ticketround/core/domain/entity/TicketRoundEntity.java
+++ b/src/main/java/com/permitseoul/permitserver/domain/ticketround/core/domain/entity/TicketRoundEntity.java
@@ -1,5 +1,6 @@
 package com.permitseoul.permitserver.domain.ticketround.core.domain.entity;
 
+import com.permitseoul.permitserver.domain.ticketround.core.exception.TicketRoundExpiredException;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -22,19 +23,21 @@ public class TicketRoundEntity {
     private String ticketRoundTitle;
 
     @Column(name = "sales_start_date", nullable = false)
-    private LocalDateTime saleStartDate;
+    private LocalDateTime salesStartDate;
 
     @Column(name = "sales_end_date", nullable = false)
     private LocalDateTime salesEndDate;
 
-    @Column(name = "is_active", nullable = false)
-    private boolean isActive;
-
-    private TicketRoundEntity(long eventId, String ticketRoundTitle, LocalDateTime saleStartDate, LocalDateTime salesEndDate, boolean isActive) {
+    private TicketRoundEntity(long eventId, String ticketRoundTitle, LocalDateTime salesStartDate, LocalDateTime salesEndDate) {
         this.eventId = eventId;
         this.ticketRoundTitle = ticketRoundTitle;
-        this.saleStartDate = saleStartDate;
+        this.salesStartDate = salesStartDate;
         this.salesEndDate = salesEndDate;
-        this.isActive = isActive;
+    }
+
+    public void verifyTicketSalesAvailable(final LocalDateTime now) {
+        if (now.isBefore(this.salesStartDate) || now.isAfter(this.salesEndDate)) {
+            throw new TicketRoundExpiredException();
+        }
     }
 }

--- a/src/main/java/com/permitseoul/permitserver/domain/ticketround/core/exception/TicketRoundCoreException.java
+++ b/src/main/java/com/permitseoul/permitserver/domain/ticketround/core/exception/TicketRoundCoreException.java
@@ -1,0 +1,6 @@
+package com.permitseoul.permitserver.domain.ticketround.core.exception;
+
+import com.permitseoul.permitserver.domain.ticket.core.exception.TicketCoreException;
+
+public abstract class TicketRoundCoreException extends TicketCoreException {
+}

--- a/src/main/java/com/permitseoul/permitserver/domain/ticketround/core/exception/TicketRoundExpiredException.java
+++ b/src/main/java/com/permitseoul/permitserver/domain/ticketround/core/exception/TicketRoundExpiredException.java
@@ -1,0 +1,6 @@
+package com.permitseoul.permitserver.domain.ticketround.core.exception;
+
+import com.permitseoul.permitserver.domain.ticket.core.exception.TicketCoreException;
+
+public class TicketRoundExpiredException extends TicketCoreException {
+}

--- a/src/main/java/com/permitseoul/permitserver/domain/ticketround/core/exception/TicketRoundNotFoundException.java
+++ b/src/main/java/com/permitseoul/permitserver/domain/ticketround/core/exception/TicketRoundNotFoundException.java
@@ -1,0 +1,4 @@
+package com.permitseoul.permitserver.domain.ticketround.core.exception;
+
+public class TicketRoundNotFoundException extends TicketRoundCoreException {
+}

--- a/src/main/java/com/permitseoul/permitserver/domain/ticketround/core/repository/TicketRoundRepository.java
+++ b/src/main/java/com/permitseoul/permitserver/domain/ticketround/core/repository/TicketRoundRepository.java
@@ -1,0 +1,9 @@
+package com.permitseoul.permitserver.domain.ticketround.core.repository;
+
+import com.permitseoul.permitserver.domain.ticketround.core.domain.entity.TicketRoundEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface TicketRoundRepository extends JpaRepository<TicketRoundEntity, Long> {
+}

--- a/src/main/java/com/permitseoul/permitserver/domain/tickettype/core/component/TicketTypeRetriever.java
+++ b/src/main/java/com/permitseoul/permitserver/domain/tickettype/core/component/TicketTypeRetriever.java
@@ -1,5 +1,6 @@
 package com.permitseoul.permitserver.domain.tickettype.core.component;
 
+import com.permitseoul.permitserver.domain.tickettype.core.domain.TicketType;
 import com.permitseoul.permitserver.domain.tickettype.core.domain.entity.TicketTypeEntity;
 import com.permitseoul.permitserver.domain.tickettype.core.exception.TicketTypeNotfoundException;
 import com.permitseoul.permitserver.domain.tickettype.core.repository.TicketTypeRepository;
@@ -15,6 +16,12 @@ public class TicketTypeRetriever {
     @Transactional(readOnly = true)
     public TicketTypeEntity findTicketTypeEntityById(final long ticketTypeId) {
         return ticketTypeRepository.findById(ticketTypeId).orElseThrow(TicketTypeNotfoundException::new);
+    }
+
+    @Transactional(readOnly = true)
+    public TicketType findTicketTypeById(final long ticketTypeId) {
+        final TicketTypeEntity ticketType = ticketTypeRepository.findById(ticketTypeId).orElseThrow(TicketTypeNotfoundException::new);
+        return TicketType.fromEntity(ticketType);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/permitseoul/permitserver/domain/tickettype/core/component/TicketTypeRetriever.java
+++ b/src/main/java/com/permitseoul/permitserver/domain/tickettype/core/component/TicketTypeRetriever.java
@@ -18,7 +18,7 @@ public class TicketTypeRetriever {
     }
 
     @Transactional(readOnly = true)
-    public void isExistByTicketTypeId(final long ticketTypeId) {
+    public void validExistTicketType(final long ticketTypeId) {
         if(!ticketTypeRepository.existsById(ticketTypeId)) {
             throw new TicketTypeNotfoundException();
         }

--- a/src/main/java/com/permitseoul/permitserver/domain/tickettype/core/domain/TicketType.java
+++ b/src/main/java/com/permitseoul/permitserver/domain/tickettype/core/domain/TicketType.java
@@ -1,0 +1,31 @@
+package com.permitseoul.permitserver.domain.tickettype.core.domain;
+
+import com.permitseoul.permitserver.domain.tickettype.core.domain.entity.TicketTypeEntity;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@RequiredArgsConstructor
+public class TicketType {
+    private final Long ticketTypeId;
+    private final long ticketRoundId;
+    private final int ticketPrice;
+    private final int totalTicketCount;
+    private final int remainTicketCount;
+    private final LocalDateTime ticketStartDate;
+    private final LocalDateTime ticketEndDate;
+
+    public static TicketType fromEntity(final TicketTypeEntity ticketTypeEntity) {
+        return new TicketType(
+                ticketTypeEntity.getTicketTypeId(),
+                ticketTypeEntity.getTicketRoundId(),
+                ticketTypeEntity.getTicketPrice(),
+                ticketTypeEntity.getTotalTicketCount(),
+                ticketTypeEntity.getRemainTicketCount(),
+                ticketTypeEntity.getTicketStartDate(),
+                ticketTypeEntity.getTicketEndDate()
+        );
+    }
+}

--- a/src/main/java/com/permitseoul/permitserver/domain/tickettype/core/domain/entity/TicketTypeEntity.java
+++ b/src/main/java/com/permitseoul/permitserver/domain/tickettype/core/domain/entity/TicketTypeEntity.java
@@ -7,6 +7,7 @@ import lombok.*;
 import java.time.LocalDateTime;
 
 @Entity
+@Getter
 @Table(name = "ticket_type")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class TicketTypeEntity {

--- a/src/main/java/com/permitseoul/permitserver/domain/user/core/component/UserRetriever.java
+++ b/src/main/java/com/permitseoul/permitserver/domain/user/core/component/UserRetriever.java
@@ -1,9 +1,9 @@
 package com.permitseoul.permitserver.domain.user.core.component;
 
+import com.permitseoul.permitserver.domain.user.core.exception.UserDuplicateException;
 import com.permitseoul.permitserver.domain.user.core.domain.SocialType;
 import com.permitseoul.permitserver.domain.user.core.domain.User;
 import com.permitseoul.permitserver.domain.user.core.domain.entity.UserEntity;
-import com.permitseoul.permitserver.domain.user.core.exception.UserExistException;
 import com.permitseoul.permitserver.domain.user.core.exception.UserNotFoundException;
 import com.permitseoul.permitserver.domain.user.core.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -21,16 +21,16 @@ public class UserRetriever {
     }
 
     @Transactional(readOnly = true)
-    public void isExistUserBySocial(final SocialType socialType, final String socialId) {
+    public void validDuplicateUserBySocial(final SocialType socialType, final String socialId) {
         if (userRepository.existsBySocialTypeAndSocialId(socialType, socialId)) {
-            throw new UserExistException();
+            throw new UserDuplicateException();
         }
     }
 
     @Transactional(readOnly = true)
-    public void isExistUserByUserId(final long userId) {
+    public void validExistUserById(final long userId) {
         if (!userRepository.existsById(userId)) {
-            throw new UserExistException();
+            throw new UserNotFoundException();
         }
     }
 

--- a/src/main/java/com/permitseoul/permitserver/domain/user/core/component/UserRetriever.java
+++ b/src/main/java/com/permitseoul/permitserver/domain/user/core/component/UserRetriever.java
@@ -21,7 +21,7 @@ public class UserRetriever {
     }
 
     @Transactional(readOnly = true)
-    public void validDuplicateUserBySocial(final SocialType socialType, final String socialId) {
+    public void validDuplicatedUserBySocial(final SocialType socialType, final String socialId) {
         if (userRepository.existsBySocialTypeAndSocialId(socialType, socialId)) {
             throw new UserDuplicateException();
         }

--- a/src/main/java/com/permitseoul/permitserver/domain/user/core/component/UserRetriever.java
+++ b/src/main/java/com/permitseoul/permitserver/domain/user/core/component/UserRetriever.java
@@ -22,7 +22,7 @@ public class UserRetriever {
 
     @Transactional(readOnly = true)
     public void isExistUserBySocial(final SocialType socialType, final String socialId) {
-        if (!userRepository.existsBySocialTypeAndSocialId(socialType, socialId)) {
+        if (userRepository.existsBySocialTypeAndSocialId(socialType, socialId)) {
             throw new UserExistException();
         }
     }

--- a/src/main/java/com/permitseoul/permitserver/domain/user/core/exception/UserDuplicateException.java
+++ b/src/main/java/com/permitseoul/permitserver/domain/user/core/exception/UserDuplicateException.java
@@ -1,0 +1,6 @@
+package com.permitseoul.permitserver.domain.user.core.exception;
+
+import com.permitseoul.permitserver.domain.auth.core.exception.AuthCoreException;
+
+public class UserDuplicateException extends AuthCoreException {
+}

--- a/src/main/java/com/permitseoul/permitserver/global/RedisProperties.java
+++ b/src/main/java/com/permitseoul/permitserver/global/RedisProperties.java
@@ -1,0 +1,10 @@
+package com.permitseoul.permitserver.global;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "spring.data.redis")
+public record RedisProperties(
+        String host,
+        int port
+) {
+}

--- a/src/main/java/com/permitseoul/permitserver/global/RedisTicketTypeCountInitializer.java
+++ b/src/main/java/com/permitseoul/permitserver/global/RedisTicketTypeCountInitializer.java
@@ -1,0 +1,31 @@
+package com.permitseoul.permitserver.global;
+
+import com.permitseoul.permitserver.domain.tickettype.core.domain.entity.TicketTypeEntity;
+import com.permitseoul.permitserver.domain.tickettype.core.repository.TicketTypeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class RedisTicketTypeCountInitializer implements ApplicationRunner {
+    private final TicketTypeRepository ticketTypeRepository;
+    private final StringRedisTemplate redisTemplate;
+
+    private static final String REDIS_TICKET_TYPE_KEY_PREFIX = "ticket_type:";
+    private static final String REDIS_TICKET_TYPE_REMAIN_SUFFIX = ":remain";
+
+    @Override
+    public void run(ApplicationArguments args) {
+        List<TicketTypeEntity> ticketTypes = ticketTypeRepository.findAll();
+
+        ticketTypes.forEach(ticketType -> {
+            String key = REDIS_TICKET_TYPE_KEY_PREFIX + ticketType.getTicketTypeId() + REDIS_TICKET_TYPE_REMAIN_SUFFIX;
+            redisTemplate.opsForValue().setIfAbsent(key, String.valueOf(ticketType.getRemainTicketCount()));
+        });
+    }
+}

--- a/src/main/java/com/permitseoul/permitserver/global/config/RedisConfig.java
+++ b/src/main/java/com/permitseoul/permitserver/global/config/RedisConfig.java
@@ -1,0 +1,37 @@
+package com.permitseoul.permitserver.global.config;
+
+import com.permitseoul.permitserver.global.RedisProperties;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+@Configuration
+@RequiredArgsConstructor
+@EnableConfigurationProperties(RedisProperties.class)
+public class RedisConfig {
+
+    private final RedisProperties redisProperties;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(redisProperties.host(), redisProperties.port());
+    }
+
+    @Bean
+    public StringRedisTemplate stringRedisTemplate(RedisConnectionFactory connectionFactory) {
+        return new StringRedisTemplate(connectionFactory);
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+        return template;
+    }
+}
+

--- a/src/main/java/com/permitseoul/permitserver/global/response/code/ErrorCode.java
+++ b/src/main/java/com/permitseoul/permitserver/global/response/code/ErrorCode.java
@@ -19,7 +19,7 @@ public enum ErrorCode implements ApiCode {
     BAD_REQUEST_NOT_READABLE(HttpStatus.BAD_REQUEST, 40005, "json 오류 혹은 reqeust body 필드 오류 입니다."),
     BAD_REQUEST_COUPON_TICKET_COUNT(HttpStatus.BAD_REQUEST, 40006, "쿠폰코드로는 하나의 티켓만 구매 가능합니다."),
     BAD_REQUEST_TICKET_SALES_EXPIRED(HttpStatus.BAD_REQUEST, 40007, "구매 날짜가 아닌 티켓입니다."),
-
+    BAD_REQUEST_TICKET_TYPE_DUPLICATED(HttpStatus.BAD_REQUEST, 40008, "같은 티켓타입 아이디 여러 개가 요청되었습니다."),
 
     /**
      * 401 Unauthorized
@@ -68,6 +68,7 @@ public enum ErrorCode implements ApiCode {
     INTEGRITY_CONFLICT(HttpStatus.CONFLICT, 40901, "데이터 무결성 위반입니다."),
     CONFLICT_INSUFFICIENT_TICKET(HttpStatus.CONFLICT, 40902, "구매하려는 티켓의 티켓 개수가 부족합니다."),
     CONFLICT_ALREADY_USED_COUPON_CODE(HttpStatus.CONFLICT, 40903, "이미 사용한 쿠폰코드입니다."),
+
 
     /**
      * 500 Internal Server Error

--- a/src/main/java/com/permitseoul/permitserver/global/response/code/ErrorCode.java
+++ b/src/main/java/com/permitseoul/permitserver/global/response/code/ErrorCode.java
@@ -79,9 +79,7 @@ public enum ErrorCode implements ApiCode {
     INTERNAL_PAYMENT_FEIGN_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 50004, "결제 feign 통신 에러입니다."),
     INTERNAL_ISO_DATE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 50005, "iso date string에서 localdate로 변환 과정 에러입니다."),
     INTERNAL_TRANSITION_ENUM_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 50006, "enum status 변환 과정 에러입니다."),
-
-
-
+    INTERNAL_SESSION_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 50007, "reservation session 저장 과정 에러입니다."),
 
 
     ;

--- a/src/main/java/com/permitseoul/permitserver/global/response/code/ErrorCode.java
+++ b/src/main/java/com/permitseoul/permitserver/global/response/code/ErrorCode.java
@@ -17,6 +17,7 @@ public enum ErrorCode implements ApiCode {
     BAD_REQUEST_MISSING_PARAM(HttpStatus.BAD_REQUEST, 40003, "필수 param이 없습니다."),
     BAD_REQUEST_METHOD_ARGUMENT_TYPE(HttpStatus.BAD_REQUEST, 40004, "메서드 인자타입이 잘못되었습니다."),
     BAD_REQUEST_NOT_READABLE(HttpStatus.BAD_REQUEST, 40005, "json 오류 혹은 reqeust body 필드 오류 입니다."),
+    BAD_REQUEST_COUPON_TICKET_COUNT(HttpStatus.BAD_REQUEST, 40006, "쿠폰코드로는 하나의 티켓만 구매 가능합니다."),
 
     /**
      * 401 Unauthorized

--- a/src/main/java/com/permitseoul/permitserver/global/response/code/ErrorCode.java
+++ b/src/main/java/com/permitseoul/permitserver/global/response/code/ErrorCode.java
@@ -18,6 +18,8 @@ public enum ErrorCode implements ApiCode {
     BAD_REQUEST_METHOD_ARGUMENT_TYPE(HttpStatus.BAD_REQUEST, 40004, "메서드 인자타입이 잘못되었습니다."),
     BAD_REQUEST_NOT_READABLE(HttpStatus.BAD_REQUEST, 40005, "json 오류 혹은 reqeust body 필드 오류 입니다."),
     BAD_REQUEST_COUPON_TICKET_COUNT(HttpStatus.BAD_REQUEST, 40006, "쿠폰코드로는 하나의 티켓만 구매 가능합니다."),
+    BAD_REQUEST_TICKET_SALES_EXPIRED(HttpStatus.BAD_REQUEST, 40007, "구매 날짜가 아닌 티켓입니다."),
+
 
     /**
      * 401 Unauthorized
@@ -51,6 +53,8 @@ public enum ErrorCode implements ApiCode {
     NOT_FOUND_PAYMENT(HttpStatus.NOT_FOUND, 40408, "해당 payment 가 없습니다."),
     NOT_FOUND_TICKET(HttpStatus.NOT_FOUND, 40409, "해당 ticket 이 없습니다."),
     NOT_FOUND_COUPON_CODE(HttpStatus.NOT_FOUND, 40410, "해당 couponCode 가 없습니다."),
+    NOT_FOUND_TICKET_ROUND(HttpStatus.NOT_FOUND, 40411, "해당 티켓 차수(round)가 없습니다."),
+
 
     /**
      * 405 Method Not Allowed

--- a/src/test/java/com/permitseoul/permitserver/domain/reservation/api/service/ReservationServiceTest.java
+++ b/src/test/java/com/permitseoul/permitserver/domain/reservation/api/service/ReservationServiceTest.java
@@ -59,9 +59,9 @@ class ReservationServiceTest {
             List<ReservationInfoRequest.TicketTypeInfo> ticketTypeInfos = List.of(
                     new ReservationInfoRequest.TicketTypeInfo(10L, 2)
             );
-            willDoNothing().given(userRetriever).isExistUserByUserId(userId);
-            willDoNothing().given(eventRetriever).isExistByEventId(eventId);
-            willDoNothing().given(ticketTypeRetriever).isExistByTicketTypeId(10L);
+            willDoNothing().given(userRetriever).validExistUserById(userId);
+            willDoNothing().given(eventRetriever).validExistEventById(eventId);
+            willDoNothing().given(ticketTypeRetriever).validExistTicketType(10L);
             willDoNothing().given(couponRetriever).isExistCoupon(couponCode);
             willDoNothing().given(couponRetriever).isCouponValid(couponCode);
             Reservation reservation = mock(Reservation.class);
@@ -73,21 +73,21 @@ class ReservationServiceTest {
         @Test
         @DisplayName("이벤트 없음 예외")
         void eventNotFound() {
-            willThrow(EventNotfoundException.class).given(eventRetriever).isExistByEventId(anyLong());
+            willThrow(EventNotfoundException.class).given(eventRetriever).validExistEventById(anyLong());
             assertThatThrownBy(() -> reservationService.saveReservation(1L, 2L, null, BigDecimal.TEN, "ORDER", List.of())).isInstanceOf(NotfoundReservationException.class);
         }
         @Test
         @DisplayName("유저 없음 예외")
         void userNotFound() {
-            willThrow(UserNotFoundException.class).given(userRetriever).isExistUserByUserId(anyLong());
+            willThrow(UserNotFoundException.class).given(userRetriever).validExistUserById(anyLong());
             assertThatThrownBy(() -> reservationService.saveReservation(1L, 2L, null, BigDecimal.TEN, "ORDER", List.of())).isInstanceOf(NotfoundReservationException.class);
         }
         @Test
         @DisplayName("쿠폰 없음 예외")
         void couponNotFound() {
-            willDoNothing().given(userRetriever).isExistUserByUserId(anyLong());
-            willDoNothing().given(eventRetriever).isExistByEventId(anyLong());
-            willDoNothing().given(ticketTypeRetriever).isExistByTicketTypeId(anyLong());
+            willDoNothing().given(userRetriever).validExistUserById(anyLong());
+            willDoNothing().given(eventRetriever).validExistEventById(anyLong());
+            willDoNothing().given(ticketTypeRetriever).validExistTicketType(anyLong());
             willThrow(CouponNotfoundException.class).given(couponRetriever).isExistCoupon(anyString());
             assertThatThrownBy(() -> reservationService.saveReservation(1L, 2L, "COUPON", BigDecimal.TEN, "ORDER", List.of(new ReservationInfoRequest.TicketTypeInfo(10L, 1))))
                     .isInstanceOf(NotfoundReservationException.class);
@@ -95,9 +95,9 @@ class ReservationServiceTest {
         @Test
         @DisplayName("쿠폰 중복 사용 예외")
         void couponConflict() {
-            willDoNothing().given(userRetriever).isExistUserByUserId(anyLong());
-            willDoNothing().given(eventRetriever).isExistByEventId(anyLong());
-            willDoNothing().given(ticketTypeRetriever).isExistByTicketTypeId(anyLong());
+            willDoNothing().given(userRetriever).validExistUserById(anyLong());
+            willDoNothing().given(eventRetriever).validExistEventById(anyLong());
+            willDoNothing().given(ticketTypeRetriever).validExistTicketType(anyLong());
             willDoNothing().given(couponRetriever).isExistCoupon(anyString());
             willThrow(CouponConflictException.class).given(couponRetriever).isCouponValid(anyString());
             assertThatThrownBy(() -> reservationService.saveReservation(1L, 2L, "COUPON", BigDecimal.TEN, "ORDER", List.of(new ReservationInfoRequest.TicketTypeInfo(10L, 1))))


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
- Resolved: #54

## 👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- 티켓 예약 방식을 변경하였습니다. 

## 1. 예약 생성 요청 API
- 우선 가장 앞단에서 redis로 티켓 타입에 따른 티켓 남은 개수를 가지고 있습니다. 요청값들을 검증한 후에, redis에 있는 것으로 개수 판별을 하여, 충분하면 예약 세션을 만들어서 클라이언트한테 쿠키로 세션키를 넘겨줍니다. 만약 redis 혹은 예약 세션을 만드는 과정에서 에러가 터지면 redis 롤백처리를 해두었습니다. 세션에는 처음 등록한 시간이 있고, 그 세션은 10분(시간 안정함)까지만 유효합니다. 예를 들어 아고다처럼 예약 페이지에 들어가면 15분~20분 예약 선점이 되는 것과 동일한 방식입니다. 추후 결제 승인 api에서 모든 결제와 티켓 발급까지 완료되면 성공값(필드)으로 바꿔줍니다.

## 2. 예약 조회 API
- 프론트엔드는 토스 위젯을 띄울 때, 쿠키에 있는 세션키로 백엔드에게 요청을 보내 예약 정보를 조회합니다.  (쿠키를 서버에서 설정해주었으므로, 프론트엔드가 따로 할 일 없음)
- 
## 3. 프론트엔드 토스 위젯
- 프론트엔드에서 토스 위젯 결제를 성공해서 successUrl을 받고, 그 안에 있는 정보들을 백엔드에게 결제 승인 api로 쏴줍니다. (물론 쿠키 세션키도 함께 오겠죠?) 

## 4. 결제 승인 API
- 백엔드에서는 세션키가 아직 세션테이블에서 유효한지 확인합니다.  백엔드에서는 세션키에 있는 예약 정보로 토스와 통신을 합니다. 성공하면 티켓 발급을 하고, 원본 DB에서 티켓 개수를 감소시킵니다.(이때는 비관적락 사용) 토스와 통신 이후부터는 한 트랜잭션으로 묶어줍니다. 마지막으로 모두 다 성공하면  또한 세션도 상태를 성공으로 바꿔줍니다.  
- 토스페이먼츠 통신 실패 -> redis 롤백 + 예약 상태를 실패 상태로 변경 + 세션 삭제
- 토스페이먼츠 통신 성공 + 그 과정에서 백엔드 실패 -> 

## 5. 스케쥴러 
- 스케쥴러로 매 1분마다(시간은 아직 안정함) 세션 테이블에서 결제 완료 및 티켓 발급까지 성공한 것들 + 10분이 지난 것들을 지워줍니다. 만약에 성공하지 않았는데, 10분이 지난 것들을 지울 때는 redis에서 개수를 롤백시킵니다.


## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- 동시성을 위해 다양한 방법을 고민했지만, 현재 가지고 있는 자원으로는 이 방법이 가장 적절하다고 판단하였습니다. 자세한 고민 과정은 블로그에 정리하도록 하겠습니다.
- 현재 예약 생성 요청 api 쪽만 수정하였습니다. 이제 다음 PR부터 나머지 처리 이어서 하도록 하겠습니다.!