### PR TITLE
feat: 행사 전체 조회 API 구현 - #67

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,4 +68,7 @@ dependencies {
 	//redis
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
+	//hashids
+	implementation 'org.hashids:hashids:1.0.3'
+
 }

--- a/src/main/java/com/permitseoul/permitserver/PermitServerApplication.java
+++ b/src/main/java/com/permitseoul/permitserver/PermitServerApplication.java
@@ -3,6 +3,8 @@ package com.permitseoul.permitserver;
 import com.permitseoul.permitserver.domain.auth.core.jwt.JwtProperties;
 import com.permitseoul.permitserver.domain.auth.core.external.google.GoogleProperties;
 import com.permitseoul.permitserver.domain.auth.core.external.kakao.KakaoProperties;
+import com.permitseoul.permitserver.domain.reservation.api.TossProperties;
+import com.permitseoul.permitserver.global.util.HashIdProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -12,7 +14,9 @@ import org.springframework.cache.annotation.EnableCaching;
 @EnableConfigurationProperties({
 		GoogleProperties.class,
 		KakaoProperties.class,
-		JwtProperties.class
+		JwtProperties.class,
+		TossProperties.class,
+		HashIdProperties.class
 })
 @SpringBootApplication
 public class PermitServerApplication {

--- a/src/main/java/com/permitseoul/permitserver/domain/auth/api/controller/AuthController.java
+++ b/src/main/java/com/permitseoul/permitserver/domain/auth/api/controller/AuthController.java
@@ -6,12 +6,11 @@ import com.permitseoul.permitserver.domain.auth.api.dto.SignUpRequest;
 import com.permitseoul.permitserver.domain.auth.core.jwt.CookieCreatorUtil;
 import com.permitseoul.permitserver.domain.auth.api.service.AuthService;
 import com.permitseoul.permitserver.global.Constants;
-import com.permitseoul.permitserver.global.resolver.user.UserId;
+import com.permitseoul.permitserver.global.resolver.user.UserIdHeader;
 import com.permitseoul.permitserver.global.response.ApiResponseUtil;
 import com.permitseoul.permitserver.global.response.BaseResponse;
 import com.permitseoul.permitserver.global.response.code.SuccessCode;
 import jakarta.servlet.http.Cookie;
-import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -65,7 +64,7 @@ public class AuthController {
     //로그아웃
     @PostMapping("/logout")
     public ResponseEntity<BaseResponse<?>> logout(
-            @UserId final Long userId,
+            @UserIdHeader final Long userId,
             @CookieValue(name = Constants.REFRESH_TOKEN) final Cookie refreshTokenCookie,
             final HttpServletResponse response
     ) {

--- a/src/main/java/com/permitseoul/permitserver/domain/event/EventBaseException.java
+++ b/src/main/java/com/permitseoul/permitserver/domain/event/EventBaseException.java
@@ -1,4 +1,4 @@
 package com.permitseoul.permitserver.domain.event;
 
-public class EventBaseException extends RuntimeException {
+public abstract class EventBaseException extends RuntimeException {
 }

--- a/src/main/java/com/permitseoul/permitserver/domain/event/EventExceptionHandler.java
+++ b/src/main/java/com/permitseoul/permitserver/domain/event/EventExceptionHandler.java
@@ -1,0 +1,16 @@
+package com.permitseoul.permitserver.domain.event;
+
+import com.permitseoul.permitserver.domain.payment.api.exception.PaymentApiException;
+import com.permitseoul.permitserver.global.response.ApiResponseUtil;
+import com.permitseoul.permitserver.global.response.BaseResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice(basePackages = "com.permitseoul.permitserver.domain.event")
+public class EventExceptionHandler {
+    @ExceptionHandler(PaymentApiException.class)
+    public ResponseEntity<BaseResponse<?>> handlePaymentApiException(final PaymentApiException e) {
+        return ApiResponseUtil.failure(e.getErrorCode());
+    }
+}

--- a/src/main/java/com/permitseoul/permitserver/domain/event/api/EventExceptionHandler.java
+++ b/src/main/java/com/permitseoul/permitserver/domain/event/api/EventExceptionHandler.java
@@ -1,6 +1,6 @@
-package com.permitseoul.permitserver.domain.event;
+package com.permitseoul.permitserver.domain.event.api;
 
-import com.permitseoul.permitserver.domain.payment.api.exception.PaymentApiException;
+import com.permitseoul.permitserver.domain.event.api.exception.EventApiException;
 import com.permitseoul.permitserver.global.response.ApiResponseUtil;
 import com.permitseoul.permitserver.global.response.BaseResponse;
 import org.springframework.http.ResponseEntity;
@@ -9,8 +9,9 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @RestControllerAdvice(basePackages = "com.permitseoul.permitserver.domain.event")
 public class EventExceptionHandler {
-    @ExceptionHandler(PaymentApiException.class)
-    public ResponseEntity<BaseResponse<?>> handlePaymentApiException(final PaymentApiException e) {
+
+    @ExceptionHandler(EventApiException.class)
+    public ResponseEntity<BaseResponse<?>> handlePaymentApiException(final EventApiException e) {
         return ApiResponseUtil.failure(e.getErrorCode());
     }
 }

--- a/src/main/java/com/permitseoul/permitserver/domain/event/api/EventExceptionHandler.java
+++ b/src/main/java/com/permitseoul/permitserver/domain/event/api/EventExceptionHandler.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 public class EventExceptionHandler {
 
     @ExceptionHandler(EventApiException.class)
-    public ResponseEntity<BaseResponse<?>> handlePaymentApiException(final EventApiException e) {
+    public ResponseEntity<BaseResponse<?>> handleEventApiException(final EventApiException e) {
         return ApiResponseUtil.failure(e.getErrorCode());
     }
 }

--- a/src/main/java/com/permitseoul/permitserver/domain/event/api/controller/EventController.java
+++ b/src/main/java/com/permitseoul/permitserver/domain/event/api/controller/EventController.java
@@ -1,0 +1,27 @@
+package com.permitseoul.permitserver.domain.event.api.controller;
+
+
+import com.permitseoul.permitserver.domain.event.api.dto.EventAllResponse;
+import com.permitseoul.permitserver.domain.event.api.service.EventService;
+import com.permitseoul.permitserver.global.response.ApiResponseUtil;
+import com.permitseoul.permitserver.global.response.BaseResponse;
+import com.permitseoul.permitserver.global.response.code.SuccessCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/events")
+public class EventController {
+    private final EventService eventService;
+
+    // 행사 전체 조회 api
+    @PostMapping()
+    public ResponseEntity<BaseResponse<?>> getAllEvents() {
+        final EventAllResponse eventAllResponse = eventService.getAllVisibleEvents();
+        return ApiResponseUtil.success(SuccessCode.OK, eventService);
+    }
+}

--- a/src/main/java/com/permitseoul/permitserver/domain/event/api/controller/EventController.java
+++ b/src/main/java/com/permitseoul/permitserver/domain/event/api/controller/EventController.java
@@ -1,16 +1,13 @@
 package com.permitseoul.permitserver.domain.event.api.controller;
 
 
-import com.permitseoul.permitserver.domain.event.api.dto.EventAllResponse;
 import com.permitseoul.permitserver.domain.event.api.service.EventService;
 import com.permitseoul.permitserver.global.response.ApiResponseUtil;
 import com.permitseoul.permitserver.global.response.BaseResponse;
 import com.permitseoul.permitserver.global.response.code.SuccessCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
 @RestController
@@ -19,9 +16,8 @@ public class EventController {
     private final EventService eventService;
 
     // 행사 전체 조회 api
-    @PostMapping()
+    @GetMapping()
     public ResponseEntity<BaseResponse<?>> getAllEvents() {
-        final EventAllResponse eventAllResponse = eventService.getAllVisibleEvents();
-        return ApiResponseUtil.success(SuccessCode.OK, eventService);
+        return ApiResponseUtil.success(SuccessCode.OK, eventService.getAllVisibleEvents());
     }
 }

--- a/src/main/java/com/permitseoul/permitserver/domain/event/api/dto/EventAllResponse.java
+++ b/src/main/java/com/permitseoul/permitserver/domain/event/api/dto/EventAllResponse.java
@@ -15,11 +15,13 @@ public record EventAllResponse(
     }
 
     public record EventInfo(
-        String eventId,
-        String eventName,
-        String thumbnailImageUrl) {
+            String eventId,
+            String eventName,
+            String thumbnailImageUrl) {
+
         public static EventInfo of(final String eventId, final String eventName, final String thumbnailImageUrl) {
             return new EventInfo(eventId, eventName, thumbnailImageUrl);
+
         }
     }
 }

--- a/src/main/java/com/permitseoul/permitserver/domain/event/api/dto/EventAllResponse.java
+++ b/src/main/java/com/permitseoul/permitserver/domain/event/api/dto/EventAllResponse.java
@@ -1,0 +1,27 @@
+package com.permitseoul.permitserver.domain.event.api.dto;
+
+import java.util.List;
+
+public record EventAllResponse(
+        List<EventInfo> permit,
+        List<EventInfo> ceilingService,
+        List<EventInfo> festival
+) {
+
+    public static EventAllResponse create(final List<EventInfo> permit,
+                                          final List<EventInfo> ceilingService,
+                                          final List<EventInfo> festival) {
+        return new EventAllResponse(permit, ceilingService, festival);
+    }
+
+    public record EventInfo(
+        String eventId,
+        String eventName,
+        String thumbnailImageUrl) {
+        public static EventInfo of(final String eventId, final String eventName, final String thumbnailImageUrl) {
+            return new EventInfo(eventId, eventName, thumbnailImageUrl);
+        }
+    }
+}
+
+

--- a/src/main/java/com/permitseoul/permitserver/domain/event/api/exception/EventApiException.java
+++ b/src/main/java/com/permitseoul/permitserver/domain/event/api/exception/EventApiException.java
@@ -1,0 +1,13 @@
+package com.permitseoul.permitserver.domain.event.api.exception;
+
+import com.permitseoul.permitserver.domain.event.EventBaseException;
+import com.permitseoul.permitserver.global.response.code.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class EventApiException extends EventBaseException {
+  private final ErrorCode errorCode;
+
+}

--- a/src/main/java/com/permitseoul/permitserver/domain/event/api/exception/EventApiException.java
+++ b/src/main/java/com/permitseoul/permitserver/domain/event/api/exception/EventApiException.java
@@ -7,7 +7,6 @@ import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
-public class EventApiException extends EventBaseException {
+public abstract class EventApiException extends EventBaseException {
   private final ErrorCode errorCode;
-
 }

--- a/src/main/java/com/permitseoul/permitserver/domain/event/api/exception/NotFoundEventException.java
+++ b/src/main/java/com/permitseoul/permitserver/domain/event/api/exception/NotFoundEventException.java
@@ -1,0 +1,9 @@
+package com.permitseoul.permitserver.domain.event.api.exception;
+
+import com.permitseoul.permitserver.global.response.code.ErrorCode;
+
+public class NotFoundEventException extends EventApiException {
+    public NotFoundEventException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/permitseoul/permitserver/domain/event/api/service/EventService.java
+++ b/src/main/java/com/permitseoul/permitserver/domain/event/api/service/EventService.java
@@ -1,16 +1,22 @@
 package com.permitseoul.permitserver.domain.event.api.service;
 
 import com.permitseoul.permitserver.domain.event.api.dto.EventAllResponse;
+import com.permitseoul.permitserver.domain.event.api.exception.NotFoundEventException;
 import com.permitseoul.permitserver.domain.event.core.component.EventRetriever;
 import com.permitseoul.permitserver.domain.event.core.domain.Event;
 import com.permitseoul.permitserver.domain.event.core.domain.EventType;
 import com.permitseoul.permitserver.domain.eventImage.core.component.EventImageRetriever;
 import com.permitseoul.permitserver.domain.eventImage.core.domain.EventImage;
+import com.permitseoul.permitserver.domain.eventImage.core.exception.EventImageNotFoundException;
+import com.permitseoul.permitserver.global.response.code.ErrorCode;
 import com.permitseoul.permitserver.global.util.SecureUrlUtil;
+import io.netty.util.internal.ObjectUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.util.ObjectUtils;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 
 @RequiredArgsConstructor
@@ -31,16 +37,23 @@ public class EventService {
     }
 
     private List<EventAllResponse.EventInfo> filteringEventByEventType(final List<Event> eventList, final EventType type) {
-        return eventList.stream()
-                .filter(event -> event.getEventType() == type)
-                .map(event -> {
-                    final EventImage thumbnailImage = eventImageRetriever.findEventThumbnailImage(event.getEventId());
-                    return EventAllResponse.EventInfo.of(
-                            SecureUrlUtil.encodeUrl(event.getEventId()),
-                            event.getName(),
-                            thumbnailImage.getImageUrl()
-                    );
-                })
-                .toList();
+        try {
+            if (ObjectUtils.isEmpty(eventList)) {
+                return List.of();
+            }
+            return eventList.stream()
+                    .filter(event -> event.getEventType() == type)
+                    .map(event -> {
+                        final EventImage thumbnailImage = eventImageRetriever.findEventThumbnailImage(event.getEventId());
+                        return EventAllResponse.EventInfo.of(
+                                SecureUrlUtil.encodeUrl(event.getEventId()),
+                                event.getName(),
+                                thumbnailImage.getImageUrl()
+                        );
+                    })
+                    .toList();
+        } catch (EventImageNotFoundException e) {
+            throw new NotFoundEventException(ErrorCode.NOT_FOUND_EVENT_IMAGE);
+        }
     }
 }

--- a/src/main/java/com/permitseoul/permitserver/domain/event/api/service/EventService.java
+++ b/src/main/java/com/permitseoul/permitserver/domain/event/api/service/EventService.java
@@ -12,6 +12,7 @@ import com.permitseoul.permitserver.global.response.code.ErrorCode;
 import com.permitseoul.permitserver.global.util.SecureUrlUtil;
 import io.netty.util.internal.ObjectUtil;
 import lombok.RequiredArgsConstructor;
+import org.hashids.Hashids;
 import org.springframework.stereotype.Service;
 import org.springframework.util.ObjectUtils;
 
@@ -24,6 +25,7 @@ import java.util.List;
 public class EventService {
     private final EventRetriever eventRetriever;
     private final EventImageRetriever eventImageRetriever;
+    private final SecureUrlUtil secureUrlUtil;
 
     public EventAllResponse getAllVisibleEvents() {
         final LocalDateTime now = LocalDateTime.now();
@@ -46,7 +48,7 @@ public class EventService {
                     .map(event -> {
                         final EventImage thumbnailImage = eventImageRetriever.findEventThumbnailImage(event.getEventId());
                         return EventAllResponse.EventInfo.of(
-                                SecureUrlUtil.encodeUrl(event.getEventId()),
+                                secureUrlUtil.encode(event.getEventId()),
                                 event.getName(),
                                 thumbnailImage.getImageUrl()
                         );

--- a/src/main/java/com/permitseoul/permitserver/domain/event/core/component/EventRetriever.java
+++ b/src/main/java/com/permitseoul/permitserver/domain/event/core/component/EventRetriever.java
@@ -8,6 +8,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
 @Component
 @RequiredArgsConstructor
 public class EventRetriever {
@@ -22,5 +25,13 @@ public class EventRetriever {
     @Transactional(readOnly = true)
     public void validExistEventById(final long eventId) {
         eventRepository.findById(eventId).orElseThrow(EventNotfoundException::new);
+    }
+
+    @Transactional(readOnly = true)
+    public List<Event> findAllVisibleEvents(final LocalDateTime now) {
+        List<EventEntity> events = eventRepository.findVisibleEvents(now);
+        return events.stream()
+                .map(Event::fromEntity)
+                .toList();
     }
 }

--- a/src/main/java/com/permitseoul/permitserver/domain/event/core/repository/EventRepository.java
+++ b/src/main/java/com/permitseoul/permitserver/domain/event/core/repository/EventRepository.java
@@ -2,8 +2,19 @@ package com.permitseoul.permitserver.domain.event.core.repository;
 
 import com.permitseoul.permitserver.domain.event.core.domain.entity.EventEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 @Repository
 public interface EventRepository extends JpaRepository<EventEntity, Long> {
+    @Query("""
+        SELECT e FROM EventEntity e
+        WHERE e.visibleStartDate <= :now
+          AND e.visibleEndDate >= :now
+    """)
+    List<EventEntity> findVisibleEvents(@Param("now") final LocalDateTime now);
 }

--- a/src/main/java/com/permitseoul/permitserver/domain/eventImage/EventImageBaseException.java
+++ b/src/main/java/com/permitseoul/permitserver/domain/eventImage/EventImageBaseException.java
@@ -1,0 +1,4 @@
+package com.permitseoul.permitserver.domain.eventImage;
+
+public abstract class EventImageBaseException extends RuntimeException {
+}

--- a/src/main/java/com/permitseoul/permitserver/domain/eventImage/core/component/EventImageRetriever.java
+++ b/src/main/java/com/permitseoul/permitserver/domain/eventImage/core/component/EventImageRetriever.java
@@ -1,0 +1,22 @@
+package com.permitseoul.permitserver.domain.eventImage.core.component;
+
+import com.permitseoul.permitserver.domain.eventImage.EventImageBaseException;
+import com.permitseoul.permitserver.domain.eventImage.core.domain.EventImage;
+import com.permitseoul.permitserver.domain.eventImage.core.domain.entity.EventImageEntity;
+import com.permitseoul.permitserver.domain.eventImage.core.exception.EventImageNotFoundException;
+import com.permitseoul.permitserver.domain.eventImage.core.repository.EventImageRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class EventImageRetriever {
+    private final EventImageRepository eventImageRepository;
+
+    @Transactional(readOnly = true)
+    public EventImage findEventThumbnailImage(final long eventId) {
+        final EventImageEntity eventImageEntity = eventImageRepository.findThumbnailImageEntityByEventId(eventId).orElseThrow(EventImageNotFoundException::new);
+        return EventImage.fromEntity(eventImageEntity);
+    }
+}

--- a/src/main/java/com/permitseoul/permitserver/domain/eventImage/core/domain/EventImage.java
+++ b/src/main/java/com/permitseoul/permitserver/domain/eventImage/core/domain/EventImage.java
@@ -1,0 +1,18 @@
+package com.permitseoul.permitserver.domain.eventImage.core.domain;
+
+import com.permitseoul.permitserver.domain.eventImage.core.domain.entity.EventImageEntity;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class EventImage {
+    private final long imageId;
+    private final long eventId;
+    private final String imageUrl;
+    private final int sequence;
+
+    public static EventImage fromEntity(final EventImageEntity eventImageEntity) {
+        return new EventImage(eventImageEntity.getEventImageId(), eventImageEntity.getEventId(), eventImageEntity.getImageUrl(), eventImageEntity.getSequence());
+    }
+}

--- a/src/main/java/com/permitseoul/permitserver/domain/eventImage/core/domain/entity/EventImageEntity.java
+++ b/src/main/java/com/permitseoul/permitserver/domain/eventImage/core/domain/entity/EventImageEntity.java
@@ -5,12 +5,13 @@ import lombok.*;
 
 @Entity
 @Table(name = "event_images")
+@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class EventImageEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "image_id", nullable = false)
-    private Long imageId;
+    @Column(name = "event_image_id", nullable = false)
+    private Long eventImageId;
 
     @Column(name = "event_id", nullable = false)
     private long eventId;
@@ -21,14 +22,10 @@ public class EventImageEntity {
     @Column(name = "sequence", nullable = false)
     private int sequence;
 
-    @Column(name = "is_thumbnail", nullable = false)
-    private boolean isThumbnail;
-
-    private EventImageEntity(long eventId, String imageUrl, int sequence, boolean isThumbnail) {
+    private EventImageEntity(long eventId, String imageUrl, int sequence) {
         this.eventId = eventId;
         this.imageUrl = imageUrl;
         this.sequence = sequence;
-        this.isThumbnail = isThumbnail;
     }
 }
 

--- a/src/main/java/com/permitseoul/permitserver/domain/eventImage/core/exception/EventImageCoreException.java
+++ b/src/main/java/com/permitseoul/permitserver/domain/eventImage/core/exception/EventImageCoreException.java
@@ -1,0 +1,6 @@
+package com.permitseoul.permitserver.domain.eventImage.core.exception;
+
+import com.permitseoul.permitserver.domain.eventImage.EventImageBaseException;
+
+public abstract class EventImageCoreException extends EventImageBaseException {
+}

--- a/src/main/java/com/permitseoul/permitserver/domain/eventImage/core/exception/EventImageNotFoundException.java
+++ b/src/main/java/com/permitseoul/permitserver/domain/eventImage/core/exception/EventImageNotFoundException.java
@@ -1,0 +1,4 @@
+package com.permitseoul.permitserver.domain.eventImage.core.exception;
+
+public class EventImageNotFoundException extends EventImageCoreException {
+}

--- a/src/main/java/com/permitseoul/permitserver/domain/eventImage/core/repository/EventImageRepository.java
+++ b/src/main/java/com/permitseoul/permitserver/domain/eventImage/core/repository/EventImageRepository.java
@@ -1,0 +1,14 @@
+package com.permitseoul.permitserver.domain.eventImage.core.repository;
+
+import com.permitseoul.permitserver.domain.eventImage.core.domain.entity.EventImageEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface EventImageRepository extends JpaRepository<EventImageEntity, Long> {
+
+    @Query("SELECT e FROM EventImageEntity e WHERE e.eventId = :eventId AND e.sequence = 0")
+    Optional<EventImageEntity> findThumbnailImageEntityByEventId(@Param("eventId") long eventId);
+}

--- a/src/main/java/com/permitseoul/permitserver/domain/payment/api/controller/PaymentController.java
+++ b/src/main/java/com/permitseoul/permitserver/domain/payment/api/controller/PaymentController.java
@@ -8,7 +8,7 @@ import com.permitseoul.permitserver.domain.payment.api.dto.PaymentConfirmRequest
 import com.permitseoul.permitserver.domain.payment.api.dto.PaymentConfirmResponse;
 import com.permitseoul.permitserver.domain.reservation.api.exception.ReservationSessionCookieException;
 import com.permitseoul.permitserver.global.domain.CookieType;
-import com.permitseoul.permitserver.global.resolver.user.UserId;
+import com.permitseoul.permitserver.global.resolver.user.UserIdHeader;
 import com.permitseoul.permitserver.global.response.ApiResponseUtil;
 import com.permitseoul.permitserver.global.response.BaseResponse;
 import com.permitseoul.permitserver.global.response.code.ErrorCode;
@@ -31,7 +31,7 @@ public class PaymentController {
     //결제 승인 api
     @PostMapping("/confirm")
     public ResponseEntity<BaseResponse<?>> getConfirmToPayment(
-            @UserId final Long userId,
+            @UserIdHeader final Long userId,
             @RequestBody @Valid final PaymentConfirmRequest paymentConfirmRequest,
             final HttpServletRequest request
     ) {
@@ -54,7 +54,7 @@ public class PaymentController {
     //결제 취소 api
     @PostMapping("/cancel")
     public ResponseEntity<BaseResponse<?>> cancelPayment(
-            @UserId final Long userId,
+            @UserIdHeader final Long userId,
             @RequestBody @Valid final PaymentCancelRequest paymentCancelRequest
     ) {
         paymentService.cancelPayment(userId, paymentCancelRequest.orderId());

--- a/src/main/java/com/permitseoul/permitserver/domain/payment/api/service/PaymentService.java
+++ b/src/main/java/com/permitseoul/permitserver/domain/payment/api/service/PaymentService.java
@@ -66,7 +66,6 @@ import java.util.List;
 
 @Slf4j
 @Service
-@EnableConfigurationProperties(TossProperties.class)
 public class PaymentService {
     private static final String COLON = ":";
     private static final String AUTH_TYPE_BASIC = "Basic ";
@@ -78,7 +77,6 @@ public class PaymentService {
     private final EventRetriever eventRetriever;
     private final TossPaymentClient tossPaymentClient;
     private final ReservationRetriever reservationRetriever;
-    private final TossProperties tossProperties;
     private final String authorizationHeader;
     private final TicketTypeRetriever ticketTypeRetriever;
     private final PaymentRetriever paymentRetriever;
@@ -104,7 +102,6 @@ public class PaymentService {
         this.eventRetriever = eventRetriever;
         this.tossPaymentClient = tossPaymentClient;
         this.reservationRetriever = reservationRetriever;
-        this.tossProperties = tossProperties;
         this.authorizationHeader = buildAuthHeader(tossProperties.apiSecretKey());
         this.ticketTypeRetriever = ticketTypeRetriever;
         this.paymentRetriever = paymentRetriever;

--- a/src/main/java/com/permitseoul/permitserver/domain/reservation/api/controller/ReservationController.java
+++ b/src/main/java/com/permitseoul/permitserver/domain/reservation/api/controller/ReservationController.java
@@ -2,13 +2,17 @@ package com.permitseoul.permitserver.domain.reservation.api.controller;
 
 import com.permitseoul.permitserver.domain.auth.core.jwt.CookieCreatorUtil;
 import com.permitseoul.permitserver.domain.auth.core.jwt.CookieExtractor;
+import com.permitseoul.permitserver.domain.payment.api.exception.NotFoundPaymentException;
 import com.permitseoul.permitserver.domain.reservation.api.dto.ReservationInfoRequest;
 import com.permitseoul.permitserver.domain.reservation.api.dto.*;
+import com.permitseoul.permitserver.domain.reservation.api.exception.NotfoundReservationException;
+import com.permitseoul.permitserver.domain.reservation.api.exception.ReservationSessionCookieException;
 import com.permitseoul.permitserver.domain.reservation.api.service.ReservationService;
 import com.permitseoul.permitserver.global.domain.CookieType;
 import com.permitseoul.permitserver.global.resolver.user.UserIdHeader;
 import com.permitseoul.permitserver.global.response.ApiResponseUtil;
 import com.permitseoul.permitserver.global.response.BaseResponse;
+import com.permitseoul.permitserver.global.response.code.ErrorCode;
 import com.permitseoul.permitserver.global.response.code.SuccessCode;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -49,8 +53,13 @@ public class ReservationController {
     public ResponseEntity<BaseResponse<?>> getReadyToPayment(
             @UserIdHeader final Long userId,
             final HttpServletRequest request
-            ) {
-        final String reservationSessionKey = CookieExtractor.extractCookie(request, CookieType.RESERVATION_SESSION).getValue();
+    ) {
+        String reservationSessionKey;
+        try {
+            reservationSessionKey = CookieExtractor.extractCookie(request, CookieType.RESERVATION_SESSION).getValue();
+        } catch (ReservationSessionCookieException e) {
+            throw new NotfoundReservationException(ErrorCode.NOT_FOUND_RESERVATION_SESSION_COOKIE);
+        }
         final ReservationInfoResponse reservationInfoResponse = reservationService.getReservationInfo(userId, reservationSessionKey);
         return ApiResponseUtil.success(SuccessCode.OK, reservationInfoResponse);
     }

--- a/src/main/java/com/permitseoul/permitserver/domain/reservation/api/controller/ReservationController.java
+++ b/src/main/java/com/permitseoul/permitserver/domain/reservation/api/controller/ReservationController.java
@@ -6,11 +6,10 @@ import com.permitseoul.permitserver.domain.reservation.api.dto.ReservationInfoRe
 import com.permitseoul.permitserver.domain.reservation.api.dto.*;
 import com.permitseoul.permitserver.domain.reservation.api.service.ReservationService;
 import com.permitseoul.permitserver.global.domain.CookieType;
-import com.permitseoul.permitserver.global.resolver.user.UserId;
+import com.permitseoul.permitserver.global.resolver.user.UserIdHeader;
 import com.permitseoul.permitserver.global.response.ApiResponseUtil;
 import com.permitseoul.permitserver.global.response.BaseResponse;
 import com.permitseoul.permitserver.global.response.code.SuccessCode;
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
@@ -28,7 +27,7 @@ public class ReservationController {
     //예약 생성 api
     @PostMapping("/ready")
     public ResponseEntity<BaseResponse<?>> saveReservation(
-            @UserId final Long userId,
+            @UserIdHeader final Long userId,
             @RequestBody @Valid final ReservationInfoRequest reservationInfoRequest,
             final HttpServletResponse response
     ) {
@@ -48,7 +47,7 @@ public class ReservationController {
     //예약 조회 api
     @GetMapping("/ready")
     public ResponseEntity<BaseResponse<?>> getReadyToPayment(
-            @UserId final Long userId,
+            @UserIdHeader final Long userId,
             final HttpServletRequest request
             ) {
         final String reservationSessionKey = CookieExtractor.extractCookie(request, CookieType.RESERVATION_SESSION).getValue();

--- a/src/main/java/com/permitseoul/permitserver/domain/reservation/api/service/ReservationService.java
+++ b/src/main/java/com/permitseoul/permitserver/domain/reservation/api/service/ReservationService.java
@@ -17,6 +17,8 @@ import com.permitseoul.permitserver.domain.reservation.core.domain.Reservation;
 import com.permitseoul.permitserver.domain.reservation.core.exception.ReservationNotFoundException;
 import com.permitseoul.permitserver.domain.reservationsession.core.component.ReservationSessionRetriever;
 import com.permitseoul.permitserver.domain.reservationsession.core.domain.ReservationSession;
+import com.permitseoul.permitserver.domain.reservationsession.core.exception.ReservationSessionNotFoundAfterPaymentSuccessException;
+import com.permitseoul.permitserver.domain.reservationsession.core.exception.ReservationSessionNotFoundException;
 import com.permitseoul.permitserver.domain.ticketround.core.component.TicketRoundRetriever;
 import com.permitseoul.permitserver.domain.ticketround.core.domain.entity.TicketRoundEntity;
 import com.permitseoul.permitserver.domain.ticketround.core.exception.TicketRoundExpiredException;
@@ -153,6 +155,8 @@ public class ReservationService {
             throw new NotfoundReservationException(ErrorCode.NOT_FOUND_USER);
         } catch (ReservationNotFoundException e) {
             throw new NotfoundReservationException(ErrorCode.NOT_FOUND_RESERVATION);
+        } catch (ReservationSessionNotFoundException e) {
+            throw new NotfoundReservationException(ErrorCode.NOT_FOUND_RESERVATION_SESSION);
         }
     }
 

--- a/src/main/java/com/permitseoul/permitserver/domain/reservation/api/service/ReservationService.java
+++ b/src/main/java/com/permitseoul/permitserver/domain/reservation/api/service/ReservationService.java
@@ -131,6 +131,31 @@ public class ReservationService {
         }
     }
 
+    @Transactional(readOnly = true)
+    public ReservationInfoResponse getReservationInfo(final long userId, final String sessionKey) {
+        try {
+            final String orderId = getOrderIdWithValidateSessionKey(userId,sessionKey);
+            final User user = userRetriever.findUserById(userId);
+            final Reservation reservation = reservationRetriever.findReservationByOrderIdAndUserId(orderId, userId);
+            final Event event = eventRetriever.findEventById(reservation.getEventId());
+
+            return ReservationInfoResponse.of(
+                    event.getName(),
+                    reservation.getOrderId(),
+                    user.getName(),
+                    user.getEmail(),
+                    reservation.getTotalAmount(),
+                    user.getSocialId()
+            );
+        } catch (EventNotfoundException e) {
+            throw new NotfoundReservationException(ErrorCode.NOT_FOUND_EVENT);
+        } catch (UserNotFoundException e) {
+            throw new NotfoundReservationException(ErrorCode.NOT_FOUND_USER);
+        } catch (ReservationNotFoundException e) {
+            throw new NotfoundReservationException(ErrorCode.NOT_FOUND_RESERVATION);
+        }
+    }
+
     private void validateTotalAmount(final Map<Long, TicketTypeEntity> ticketTypeEntityMap,
                                      final List<ReservationInfoRequest.TicketTypeInfo> requestTicketTypeInfos,
                                      final BigDecimal totalAmount,
@@ -156,31 +181,6 @@ public class ReservationService {
 
         if (calculatedAmount.compareTo(totalAmount) != 0) {
             throw new ReservationBadRequestException(ErrorCode.BAD_REQUEST_AMOUNT_MISMATCH);
-        }
-    }
-
-    @Transactional(readOnly = true)
-    public ReservationInfoResponse getReservationInfo(final long userId, final String sessionKey) {
-        try {
-            final String orderId = getOrderIdWithValidateSessionKey(userId,sessionKey);
-            final User user = userRetriever.findUserById(userId);
-            final Reservation reservation = reservationRetriever.findReservationByOrderIdAndUserId(orderId, userId);
-            final Event event = eventRetriever.findEventById(reservation.getEventId());
-
-            return ReservationInfoResponse.of(
-                    event.getName(),
-                    reservation.getOrderId(),
-                    user.getName(),
-                    user.getEmail(),
-                    reservation.getTotalAmount(),
-                    user.getSocialId()
-            );
-        } catch (EventNotfoundException e) {
-            throw new NotfoundReservationException(ErrorCode.NOT_FOUND_EVENT);
-        } catch (UserNotFoundException e) {
-            throw new NotfoundReservationException(ErrorCode.NOT_FOUND_USER);
-        } catch (ReservationNotFoundException e) {
-            throw new NotfoundReservationException(ErrorCode.NOT_FOUND_RESERVATION);
         }
     }
 

--- a/src/main/java/com/permitseoul/permitserver/global/RedisTicketTypeCountInitializer.java
+++ b/src/main/java/com/permitseoul/permitserver/global/RedisTicketTypeCountInitializer.java
@@ -3,7 +3,6 @@ package com.permitseoul.permitserver.global;
 import com.permitseoul.permitserver.domain.tickettype.core.domain.entity.TicketTypeEntity;
 import com.permitseoul.permitserver.domain.tickettype.core.repository.TicketTypeRepository;
 import lombok.RequiredArgsConstructor;
-import org.apache.tomcat.util.bcel.Const;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.data.redis.core.StringRedisTemplate;

--- a/src/main/java/com/permitseoul/permitserver/global/config/SecurityConfig.java
+++ b/src/main/java/com/permitseoul/permitserver/global/config/SecurityConfig.java
@@ -31,6 +31,7 @@ public class SecurityConfig {
             "/api/users/signup",
             "/api/users/login",
             "/api/users/reissue",
+            "/api/events"
     };
 
     private static final String[] adminURIList = {

--- a/src/main/java/com/permitseoul/permitserver/global/exception/UrlDecodeException.java
+++ b/src/main/java/com/permitseoul/permitserver/global/exception/UrlDecodeException.java
@@ -1,0 +1,13 @@
+package com.permitseoul.permitserver.global.exception;
+
+import com.permitseoul.permitserver.global.response.code.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class UrlDecodeException extends PermitGlobalException {
+
+    private final ErrorCode errorCode;
+    public UrlDecodeException(ErrorCode errorCode) {
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/permitseoul/permitserver/global/exception/UrlSecureException.java
+++ b/src/main/java/com/permitseoul/permitserver/global/exception/UrlSecureException.java
@@ -4,10 +4,10 @@ import com.permitseoul.permitserver.global.response.code.ErrorCode;
 import lombok.Getter;
 
 @Getter
-public class UrlDecodeException extends PermitGlobalException {
+public class UrlSecureException extends PermitGlobalException {
 
     private final ErrorCode errorCode;
-    public UrlDecodeException(ErrorCode errorCode) {
+    public UrlSecureException(ErrorCode errorCode) {
         this.errorCode = errorCode;
     }
 }

--- a/src/main/java/com/permitseoul/permitserver/global/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/permitseoul/permitserver/global/handler/GlobalExceptionHandler.java
@@ -3,7 +3,9 @@ package com.permitseoul.permitserver.global.handler;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.permitseoul.permitserver.global.exception.FilterException;
+import com.permitseoul.permitserver.global.exception.PermitGlobalException;
 import com.permitseoul.permitserver.global.exception.ResolverException;
+import com.permitseoul.permitserver.global.exception.UrlDecodeException;
 import com.permitseoul.permitserver.global.response.ApiResponseUtil;
 import com.permitseoul.permitserver.global.response.BaseResponse;
 import com.permitseoul.permitserver.global.response.code.ErrorCode;
@@ -48,6 +50,16 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(JsonProcessingException.class)
     public ResponseEntity<BaseResponse<?>> handleJsonProcessingException(final JsonProcessingException e) {
         return ApiResponseUtil.failure(ErrorCode.INTERNAL_JSON_FORMAT_ERROR);
+    }
+
+    @ExceptionHandler(PermitGlobalException.class)
+    public ResponseEntity<BaseResponse<?>> handlePermitGlobalException(final PermitGlobalException e) {
+        return ApiResponseUtil.failure(ErrorCode.INTERNAL_SERVER_ERROR, e.getMessage());
+    }
+
+    @ExceptionHandler(UrlDecodeException.class)
+    public ResponseEntity<BaseResponse<?>> handleUrlDecodeException(final UrlDecodeException e) {
+        return ApiResponseUtil.failure(e.getErrorCode());
     }
 
     /**

--- a/src/main/java/com/permitseoul/permitserver/global/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/permitseoul/permitserver/global/handler/GlobalExceptionHandler.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.databind.JsonMappingException;
 import com.permitseoul.permitserver.global.exception.FilterException;
 import com.permitseoul.permitserver.global.exception.PermitGlobalException;
 import com.permitseoul.permitserver.global.exception.ResolverException;
-import com.permitseoul.permitserver.global.exception.UrlDecodeException;
+import com.permitseoul.permitserver.global.exception.UrlSecureException;
 import com.permitseoul.permitserver.global.response.ApiResponseUtil;
 import com.permitseoul.permitserver.global.response.BaseResponse;
 import com.permitseoul.permitserver.global.response.code.ErrorCode;
@@ -57,8 +57,8 @@ public class GlobalExceptionHandler {
         return ApiResponseUtil.failure(ErrorCode.INTERNAL_SERVER_ERROR, e.getMessage());
     }
 
-    @ExceptionHandler(UrlDecodeException.class)
-    public ResponseEntity<BaseResponse<?>> handleUrlDecodeException(final UrlDecodeException e) {
+    @ExceptionHandler(UrlSecureException.class)
+    public ResponseEntity<BaseResponse<?>> handleUrlDecodeException(final UrlSecureException e) {
         return ApiResponseUtil.failure(e.getErrorCode());
     }
 

--- a/src/main/java/com/permitseoul/permitserver/global/resolver/event/EventIdPathVariable.java
+++ b/src/main/java/com/permitseoul/permitserver/global/resolver/event/EventIdPathVariable.java
@@ -1,0 +1,11 @@
+package com.permitseoul.permitserver.global.resolver.event;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface EventIdPathVariable {
+}

--- a/src/main/java/com/permitseoul/permitserver/global/resolver/event/EventIdPathVariableResolver.java
+++ b/src/main/java/com/permitseoul/permitserver/global/resolver/event/EventIdPathVariableResolver.java
@@ -1,0 +1,42 @@
+package com.permitseoul.permitserver.global.resolver.event;
+
+
+import com.permitseoul.permitserver.global.exception.UrlSecureException;
+import com.permitseoul.permitserver.global.response.code.ErrorCode;
+import com.permitseoul.permitserver.global.util.SecureUrlUtil;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+import org.springframework.web.servlet.HandlerMapping;
+
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class EventIdPathVariableResolver implements HandlerMethodArgumentResolver {
+    private static final String EVENT_ID_PATH_VARIABLE = "eventId";
+    private final SecureUrlUtil secureUrlUtil;
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(EventIdPathVariable.class);
+    }
+
+    @Override
+    public Long resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+        final HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
+        final Map<String, String> pathVariables = (Map<String, String>) request.getAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE);
+
+        final String eventId = pathVariables.get(EVENT_ID_PATH_VARIABLE);
+        try {
+            return secureUrlUtil.decode(eventId);
+        } catch (Exception e) {
+            throw new UrlSecureException(ErrorCode.BAD_REQUEST_ID_DECODE_ERROR);
+        }
+    }
+}

--- a/src/main/java/com/permitseoul/permitserver/global/resolver/user/UserIdHeader.java
+++ b/src/main/java/com/permitseoul/permitserver/global/resolver/user/UserIdHeader.java
@@ -7,5 +7,5 @@ import java.lang.annotation.Target;
 
 @Target(ElementType.PARAMETER)
 @Retention(RetentionPolicy.RUNTIME)
-public @interface UserId {
+public @interface UserIdHeader {
 }

--- a/src/main/java/com/permitseoul/permitserver/global/resolver/user/UserIdHeaderResolver.java
+++ b/src/main/java/com/permitseoul/permitserver/global/resolver/user/UserIdHeaderResolver.java
@@ -21,11 +21,11 @@ public class UserIdHeaderResolver implements HandlerMethodArgumentResolver {
     @Override
     public boolean supportsParameter(MethodParameter parameter) {
         return (parameter.getParameterType().equals(Long.class) || parameter.getParameterType().equals(long.class))
-                && parameter.hasParameterAnnotation(UserId.class);
+                && parameter.hasParameterAnnotation(UserIdHeader.class);
     }
 
     @Override
-    public Object resolveArgument(MethodParameter parameter,
+    public Long resolveArgument(MethodParameter parameter,
                                   ModelAndViewContainer mavContainer,
                                   NativeWebRequest webRequest,
                                   WebDataBinderFactory binderFactory) {
@@ -38,6 +38,6 @@ public class UserIdHeaderResolver implements HandlerMethodArgumentResolver {
         if (principal == null || principal.equals(ANONY_USER)) {
             throw new ResolverException(ErrorCode.UNAUTHORIZED_SECURITY_ENTRY);
         }
-        return principal;
+        return (Long) principal;
     }
 }

--- a/src/main/java/com/permitseoul/permitserver/global/response/code/ErrorCode.java
+++ b/src/main/java/com/permitseoul/permitserver/global/response/code/ErrorCode.java
@@ -23,6 +23,8 @@ public enum ErrorCode implements ApiCode {
     BAD_REQUEST_SESSION_ORDER_ID(HttpStatus.BAD_REQUEST, 40009, "예약 세션에 있는 orderId와 요청하신 orderId가 다릅니다."),
     BAD_REQUEST_TICKET_COUNT_ZERO(HttpStatus.BAD_REQUEST, 40010, "구매하려는 티켓 개수가 1보다 작습니다."),
     BAD_REQUEST_AMOUNT_MISMATCH(HttpStatus.BAD_REQUEST, 40011, "구매하려는 티켓들의 가격과 totalAmount가 다릅니다."),
+    BAD_REQUEST_ID_DECODE_ERROR(HttpStatus.BAD_REQUEST, 40012, "해당 객체 id를 decode 할 수 없습니다."),
+
 
     /**
      * 401 Unauthorized

--- a/src/main/java/com/permitseoul/permitserver/global/response/code/ErrorCode.java
+++ b/src/main/java/com/permitseoul/permitserver/global/response/code/ErrorCode.java
@@ -63,6 +63,8 @@ public enum ErrorCode implements ApiCode {
     NOT_FOUND_RESERVATION_SESSION(HttpStatus.NOT_FOUND, 40413, "예약 세션이 없습니다."),
     NOT_FOUND_RESERVATION_SESSION_AFTER_PAYMENT_SUCCESS(HttpStatus.NOT_FOUND, 40414, "결제 완료 후, 예약 세션이 없습니다."),
     NOT_FOUND_RESERVATION_SESSION_COOKIE(HttpStatus.NOT_FOUND, 40414, "세션 쿠키가 없습니다."),
+    NOT_FOUND_EVENT_IMAGE(HttpStatus.NOT_FOUND, 40415, "해당 이벤트 이미지가 없습니다."),
+
 
 
     /**

--- a/src/main/java/com/permitseoul/permitserver/global/response/code/ErrorCode.java
+++ b/src/main/java/com/permitseoul/permitserver/global/response/code/ErrorCode.java
@@ -90,6 +90,8 @@ public enum ErrorCode implements ApiCode {
     INTERNAL_ISO_DATE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 50005, "iso date string에서 localdate로 변환 과정 에러입니다."),
     INTERNAL_TRANSITION_ENUM_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 50006, "enum status 변환 과정 에러입니다."),
     INTERNAL_SESSION_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 50007, "reservation session 저장 과정 에러입니다."),
+    INTERNAL_ID_ENCODE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 50008, "객체 id Encoding 에러입니다."),
+
 
 
     ;

--- a/src/main/java/com/permitseoul/permitserver/global/util/HashIdProperties.java
+++ b/src/main/java/com/permitseoul/permitserver/global/util/HashIdProperties.java
@@ -1,0 +1,10 @@
+package com.permitseoul.permitserver.global.util;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "hashids")
+public record HashIdProperties(
+        String salt,
+        int length
+) {
+}

--- a/src/main/java/com/permitseoul/permitserver/global/util/SecureUrlUtil.java
+++ b/src/main/java/com/permitseoul/permitserver/global/util/SecureUrlUtil.java
@@ -1,5 +1,7 @@
 package com.permitseoul.permitserver.global.util;
 
+import com.permitseoul.permitserver.global.exception.UrlSecureException;
+import com.permitseoul.permitserver.global.response.code.ErrorCode;
 import org.hashids.Hashids;
 import org.springframework.stereotype.Component;
 
@@ -12,17 +14,17 @@ public class SecureUrlUtil {
         this.hashids = new Hashids(hashIdProperties.salt(), hashIdProperties.length());
     }
 
-    public String encode(Long id) {
+    public String encode(final Long id) {
         if (id == null) {
-            throw new IllegalArgumentException("ID must not be null");
+            throw new UrlSecureException(ErrorCode.INTERNAL_ID_ENCODE_ERROR);
         }
         return hashids.encode(id);
     }
 
-    public Long decode(String hash) {
-        long[] decoded = hashids.decode(hash);
+    public long decode(final String hash) {
+        final long[] decoded = hashids.decode(hash);
         if (decoded.length == 0) {
-            throw new IllegalArgumentException("Invalid Hash ID: " + hash);
+            throw new UrlSecureException(ErrorCode.BAD_REQUEST_ID_DECODE_ERROR);
         }
         return decoded[0];
     }

--- a/src/main/java/com/permitseoul/permitserver/global/util/SecureUrlUtil.java
+++ b/src/main/java/com/permitseoul/permitserver/global/util/SecureUrlUtil.java
@@ -1,23 +1,29 @@
 package com.permitseoul.permitserver.global.util;
 
-import com.permitseoul.permitserver.global.exception.UrlSecureException;
-import com.permitseoul.permitserver.global.response.code.ErrorCode;
+import org.hashids.Hashids;
+import org.springframework.stereotype.Component;
 
-import java.util.Base64;
 
-public abstract class SecureUrlUtil {
-    public static String encodeUrl(final Long id) {
-        if (id == null) {
-            throw new UrlSecureException(ErrorCode.INTERNAL_ID_ENCODE_ERROR);
-        }
-        return Base64.getUrlEncoder().encodeToString(id.toString().getBytes());
+@Component
+public class SecureUrlUtil {
+    private final Hashids hashids;
+
+    public SecureUrlUtil (final HashIdProperties hashIdProperties) {
+        this.hashids = new Hashids(hashIdProperties.salt(), hashIdProperties.length());
     }
 
-    public static Long decodeUrl(final String url) {
-        try {
-            return Long.parseLong(new String(Base64.getUrlDecoder().decode(url)));
-        } catch (IllegalArgumentException e) {
-            throw new UrlSecureException(ErrorCode.BAD_REQUEST_ID_DECODE_ERROR);
+    public String encode(Long id) {
+        if (id == null) {
+            throw new IllegalArgumentException("ID must not be null");
         }
+        return hashids.encode(id);
+    }
+
+    public Long decode(String hash) {
+        long[] decoded = hashids.decode(hash);
+        if (decoded.length == 0) {
+            throw new IllegalArgumentException("Invalid Hash ID: " + hash);
+        }
+        return decoded[0];
     }
 }

--- a/src/main/java/com/permitseoul/permitserver/global/util/SecureUrlUtil.java
+++ b/src/main/java/com/permitseoul/permitserver/global/util/SecureUrlUtil.java
@@ -1,0 +1,20 @@
+package com.permitseoul.permitserver.global.util;
+
+import com.permitseoul.permitserver.global.exception.UrlDecodeException;
+import com.permitseoul.permitserver.global.response.code.ErrorCode;
+
+import java.util.Base64;
+
+public abstract class SecureUrlUtil {
+    public static String encodeUrl(final Long id) {
+        return Base64.getUrlEncoder().encodeToString(id.toString().getBytes());
+    }
+
+    public static Long decodeUrl(final String url) {
+        try {
+            return Long.parseLong(new String(Base64.getUrlDecoder().decode(url)));
+        } catch (IllegalArgumentException e) {
+            throw new UrlDecodeException(ErrorCode.BAD_REQUEST_ID_DECODE_ERROR);
+        }
+    }
+}

--- a/src/main/java/com/permitseoul/permitserver/global/util/SecureUrlUtil.java
+++ b/src/main/java/com/permitseoul/permitserver/global/util/SecureUrlUtil.java
@@ -1,12 +1,15 @@
 package com.permitseoul.permitserver.global.util;
 
-import com.permitseoul.permitserver.global.exception.UrlDecodeException;
+import com.permitseoul.permitserver.global.exception.UrlSecureException;
 import com.permitseoul.permitserver.global.response.code.ErrorCode;
 
 import java.util.Base64;
 
 public abstract class SecureUrlUtil {
     public static String encodeUrl(final Long id) {
+        if (id == null) {
+            throw new UrlSecureException(ErrorCode.INTERNAL_ID_ENCODE_ERROR);
+        }
         return Base64.getUrlEncoder().encodeToString(id.toString().getBytes());
     }
 
@@ -14,7 +17,7 @@ public abstract class SecureUrlUtil {
         try {
             return Long.parseLong(new String(Base64.getUrlDecoder().decode(url)));
         } catch (IllegalArgumentException e) {
-            throw new UrlDecodeException(ErrorCode.BAD_REQUEST_ID_DECODE_ERROR);
+            throw new UrlSecureException(ErrorCode.BAD_REQUEST_ID_DECODE_ERROR);
         }
     }
 }


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
- Resolved: #67 

## 👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- 행사 전체 조회 api 구현
- eventId를 내려줄 때, hashids로 변환해서 내려줌
- 추후에 path variable로 받을 때 다시 decode하는 것까지 만들어둠(resolver 와 custom annotation 사용)
## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
